### PR TITLE
fix: prevent negative values in budget set limit input

### DIFF
--- a/src/pages/Budgets.jsx
+++ b/src/pages/Budgets.jsx
@@ -29,11 +29,15 @@ export default function Budgets() {
             <input
               type="number"
               placeholder="Set limit"
+              min="0"
               className="retro-input p-3 w-full"
               value={budgets[category] || ""}
-              onChange={(e) =>
-                setBudgets({ ...budgets, [category]: Number(e.target.value) })
-              }
+              onChange={(e) => {
+                const val = Number(e.target.value);
+                if (val >= 0 || e.target.value === "") {
+                  setBudgets({ ...budgets, [category]: val });
+                }
+              }}
             />
             {budgets[category] && (
               <div className="pt-2">


### PR DESCRIPTION
## Summary
Closes #7

Budget limits should not accept negative values since they represent monetary amounts.

## Changes
- **`src/pages/Budgets.jsx`**: 
  - Added `min="0"` attribute to the budget limit input field
  - Added validation in `onChange` handler to reject negative values
  - Allows clearing the field (empty string) for user convenience

## Before
The input accepted any numeric value including negative numbers.

## After
- Input has `min="0"` attribute (HTML-level validation)
- `onChange` handler discards negative values at the React state level
- Empty string is still accepted for clearing the field