### PR TITLE
feat: add clear data control

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -5,9 +5,12 @@ import { demoData } from "../data/demoData";
 export default function CSVParser() {
   const { transactions, setTransactions } = useContext(DataContext);
   const [data, setData] = useState([]);
+  const [message, setMessage] = useState("");
+  const hasTransactions = transactions?.length > 0;
 
   const handleFile = (e) => {
     const file = e.target.files[0];
+    if (!file) return;
 
     Papa.parse(file, {
       header: true,
@@ -16,8 +19,22 @@ export default function CSVParser() {
         setData(results.data);
         localStorage.setItem("transactions", JSON.stringify(results.data));
         setTransactions(results.data);
+        setMessage("Data loaded successfully!");
       },
     });
+  };
+
+  const handleClearData = () => {
+    const confirmed = window.confirm(
+      "Clear all saved transaction data? This cannot be undone.",
+    );
+
+    if (!confirmed) return;
+
+    localStorage.removeItem("transactions");
+    setTransactions([]);
+    setData([]);
+    setMessage("Transaction data cleared. You can upload a new CSV anytime.");
   };
 
   return (
@@ -46,6 +63,7 @@ export default function CSVParser() {
               onClick={() => {
                 setTransactions(demoData);
                 localStorage.setItem("transactions", JSON.stringify(demoData));
+                setMessage("Demo data loaded successfully!");
               }}
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="square" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
@@ -53,6 +71,29 @@ export default function CSVParser() {
             </button>
           </div>
         </div>
+      </div>
+
+      {message && (
+        <div className="retro-card border-[#FF6B00] p-4 mb-8 text-sm font-bold uppercase tracking-wider text-[#FFB266]">
+          {message}
+        </div>
+      )}
+
+      <div className="retro-card p-8 mb-8">
+        <h2 className="text-[#FF6B00] text-lg font-black uppercase tracking-widest mb-4">
+          Reset Data
+        </h2>
+        <p className="text-gray-400 mb-6 leading-relaxed">
+          Clear saved transactions from this browser and start fresh with a new
+          CSV file.
+        </p>
+        <button
+          className="w-full md:w-auto border border-red-500 px-6 py-3 font-bold uppercase text-red-300 transition-colors hover:bg-red-500 hover:text-black disabled:cursor-not-allowed disabled:border-gray-700 disabled:text-gray-600 disabled:hover:bg-transparent"
+          onClick={handleClearData}
+          disabled={!hasTransactions}
+        >
+          Clear Data
+        </button>
       </div>
 
       {data && data.length > 0 && (


### PR DESCRIPTION
Closes #12.

## Summary
- Add a Reset Data section on the Settings page.
- Confirm before clearing saved transaction data.
- Remove saved transactions from localStorage, reset app context state, clear parsed preview data, and show a status message.
- Keep the existing CSV upload and demo data flows working, with success feedback.

## Testing
- `git diff --check`
- `npm ci` could not complete locally because this machine ran out of disk space while writing `node_modules` (`ENOSPC: no space left on device`).

## Notes
I commented on the issue before opening this PR and kept the scope limited to the requested Settings-page control.