### PR TITLE
fix: update sidebar footer icon to LinkedIn profile

### DIFF
--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -68,11 +68,11 @@ export default function Sidebar() {
         
         {/* Portfolio Link - Opens in a new tab */}
         <a 
-          href="#" 
+          href="https://www.linkedin.com/in/irfankhan1855/" 
           target="_blank" 
           rel="noopener noreferrer" 
           className="text-gray-400 hover:text-[#FF6B00] transition-colors hover:scale-110"
-          title="Portfolio"
+          title="LinkedIn"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect>


### PR DESCRIPTION
## 🐛 Bug Fixed
Clicking orange icon in sidebar footer was redirecting to broken `/settings#` route (404 error)

## ✅ Changes Made
- Replaced broken link with LinkedIn profile URL (irfankhan1855)
- Changed title from "Portfolio" to "LinkedIn"
- Kept orange icon unchanged as requested

## 🧪 Testing Done
- ✅ Orange icon opens LinkedIn profile in new tab
- ✅ GitHub icon still works correctly
- ✅ No 404 errors

## 📸 Screenshots
<img width="1918" height="1020" alt="linkedin-profile png" src="https://github.com/user-attachments/assets/6b5b6f16-db1b-4a3c-bba5-ddb35729ee44" />
<img width="1918" height="1020" alt="sidebar-orange-icon png" src="https://github.com/user-attachments/assets/3e6f13b8-9e3b-494c-b57f-48e40c79c81e" />
<img width="1918" height="1020" alt="terminal-running png" src="https://github.com/user-attachments/assets/e2938f9c-8922-491d-bfc8-c63c2706bdaa" />
<img width="1918" height="1015" alt="web-homepage png" src="https://github.com/user-attachments/assets/c667dd49-696b-40e7-8af5-312ca9e11852" />


## 🔗 Related Issue
Fixes #20