### PR TITLE
Add icons to dashboard summary cards

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -15,6 +15,7 @@ import {
 } from "recharts";
 import React from "react";
 import { parse, format } from "date-fns";
+import { TrendingUp, TrendingDown, PiggyBank } from "lucide-react";
 
 export default function Dashboard() {
   const { transactions, currency } = React.useContext(DataContext);
@@ -119,9 +120,14 @@ export default function Dashboard() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
 
             <div className="retro-card p-6 flex flex-col justify-center">
-              <h2 className="text-gray-400 text-sm font-semibold tracking-widest uppercase mb-2">
-                Income
-              </h2>
+              <div className="flex items-center justify-between">
+                <h2 className="text-gray-400 text-sm font-semibold tracking-widest uppercase mb-2">
+                  Income
+                </h2>
+                <div className="p-2 bg-[#161616] border border-fin-border">
+                  <TrendingUp className="w-5 h-5 text-[#00C49F]" />
+                </div>
+              </div>
 
               <p className="text-[#00C49F] text-3xl font-black">
                 {currency.symbol}
@@ -130,9 +136,14 @@ export default function Dashboard() {
             </div>
 
             <div className="retro-card p-6 flex flex-col justify-center">
-              <h2 className="text-gray-400 text-sm font-semibold tracking-widest uppercase mb-2">
-                Spent
-              </h2>
+              <div className="flex items-center justify-between">
+                <h2 className="text-gray-400 text-sm font-semibold tracking-widest uppercase mb-2">
+                  Spent
+                </h2>
+                <div className="p-2 bg-[#161616] border border-fin-border">
+                  <TrendingDown className="w-5 h-5 text-[#FF6B6B]" />
+                </div>
+              </div>
 
               <p className="text-[#FF6B6B] text-3xl font-black">
                 {currency.symbol}
@@ -141,9 +152,14 @@ export default function Dashboard() {
             </div>
 
             <div className="retro-card p-6 flex flex-col justify-center">
-              <h2 className="text-gray-400 text-sm font-semibold tracking-widest uppercase mb-2">
-                Savings
-              </h2>
+              <div className="flex items-center justify-between">
+                <h2 className="text-gray-400 text-sm font-semibold tracking-widest uppercase mb-2">
+                  Savings
+                </h2>
+                <div className="p-2 bg-[#161616] border border-fin-border">
+                  <PiggyBank className="w-5 h-5 text-[#0088FE]" />
+                </div>
+              </div>
 
               <p className="text-[#0088FE] text-3xl font-black">
                 {currency.symbol}


### PR DESCRIPTION
## Description

This PR enhances the dashboard summary cards by adding relevant icons and improving the overall visual consistency of the UI.

## Changes Made

* Added icons for Income, Spent, and Savings summary cards
* Improved alignment and spacing inside cards
* Enhanced dashboard appearance and readability

## Screenshots

### Before

<img width="1596" height="213" alt="image" src="https://github.com/user-attachments/assets/06418a3a-ce36-4ec5-be33-86847bd7f5d3" />

### After

<img width="1598" height="226" alt="image" src="https://github.com/user-attachments/assets/ae21f208-9d11-4aa1-9b91-b6d745e4a7b5" />

Closes #65
