### PR TITLE
fix: move spending calculation above useEffect to prevent undefined reference

### DIFF
--- a/src/pages/Budgets.jsx
+++ b/src/pages/Budgets.jsx
@@ -14,6 +14,13 @@ export default function Budgets() {
   const [showAlert, setShowAlert] = React.useState(false);
   const [exceededCategories, setExceededCategories] = React.useState([]);
   const { transactions, currency } = React.useContext(DataContext);
+  const spending = transactions
+    ?.filter((t) => Number(t.Amount) < 0)
+    .reduce((acc, item) => {
+      const category = categorize(item.Description);
+      acc[category] = (acc[category] || 0) + Math.abs(Number(item.Amount));
+      return acc;
+    }, {});
 
   // Save budgets to localStorage whenever they change
   React.useEffect(() => {
@@ -37,15 +44,8 @@ export default function Budgets() {
     if (exceeded.length > 0) {
       setShowAlert(true);
     }
-  }, [budgets, transactions]);
+  }, [budgets, transactions, spending]);
 
-  const spending = transactions
-    ?.filter((t) => Number(t.Amount) < 0)
-    .reduce((acc, item) => {
-      const category = categorize(item.Description);
-      acc[category] = (acc[category] || 0) + Math.abs(Number(item.Amount));
-      return acc;
-    }, {});
   const categories = Object.keys(spending || {});
 
   // Prepare comparison chart data


### PR DESCRIPTION
## Description
In `src/pages/Budgets.jsx`, the `spending` variable was defined after the `useEffect` that referenced it. Since `const` declarations are not hoisted, `spending` was `undefined` when the budget exceeded check ran — meaning `Object.keys(budgets).forEach` could never find any exceeded categories and the budget alert never fired, even when spending clearly exceeded the set limit.

**Changes:**
- Moved `spending` calculation above both `useEffect` calls so it is defined before any effect references it
- Added `spending` to the dependency array of the budget exceeded `useEffect`

## How to Test
1. Upload a CSV with transactions
2. Go to the Budgets page
3. Set a budget for any category lower than the current spending
4. Observe that the budget exceeded alert now correctly appears

Closes #67