### PR TITLE
fix: transactions history overrides original currency format based on active global settings-57

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -125,6 +125,7 @@ export default function CSVParser() {
       Date: manualTransaction.Date,
       Description: manualTransaction.Description,
       Amount: manualTransaction.Amount,
+      Currency: currency,
     };
 
     const updatedTransactions = [

--- a/src/pages/Transaction.jsx
+++ b/src/pages/Transaction.jsx
@@ -328,7 +328,9 @@ export default function Transaction() {
                 <td className="py-4 px-6 text-gray-400 whitespace-nowrap">{data.Date}</td>
                 <td className="py-4 px-6 font-medium max-w-sm truncate" title={data.Description}>{data.Description}</td>
                 <td className={`py-4 px-6 font-black text-right whitespace-nowrap ${Number(data.Amount) > 0 ? 'text-[#00C49F]' : 'text-white'}`}>
-                  {Number(data.Amount) > 0 ? '+' : ''}{currency.symbol}{Math.abs(Number(data.Amount)).toLocaleString()}
+                  {Number(data.Amount) > 0 ? '+' : ''}
+                  {data.Currency?.symbol || currency.symbol}
+                  {Math.abs(Number(data.Amount)).toLocaleString()}
                 </td>
                 <td className="py-4 px-6">
                   <span className="bg-[#1F1F1F] text-gray-300 px-3 py-1 text-xs font-bold uppercase tracking-wider rounded-sm border border-[#2a2a2a]">


### PR DESCRIPTION
## Description
Fixed the global currency leak where changing the currency in the settings panel would retroactively alter the currency symbols of all past transaction history. 

## Problem
Closes #57 

## The Problem
Previously, the `Transaction` list component used the global `currency` state from `AppContext` to render the symbol for every single transaction. This meant if a user changed their default currency from INR to USD, their entire historical record would incorrectly update to show USD symbols.


## The Solution
1. **Localized Currency Identity:** Updated the manual transaction creation step to snapshot and permanently attach the active global `currency` configuration (`Currency: currency`) directly to the transaction object at the moment it is created.
2. **Resilient Rendering:** Updated the `Transaction` rendering component to check for the transaction's own historical `data.Currency.symbol` first, falling back to the global setting only for older, legacy data.
<img width="1443" height="822" alt="image" src="https://github.com/user-attachments/assets/511d0423-eac0-4065-935f-483e3dec4172" />
<img width="1419" height="247" alt="image" src="https://github.com/user-attachments/assets/59d12c58-1a8e-407c-bbb2-5d869febce74" />
<img width="1356" height="786" alt="image" src="https://github.com/user-attachments/assets/1562bb5b-0649-4d6f-9c11-dce139f61938" />
<img width="1430" height="260" alt="image" src="https://github.com/user-attachments/assets/43875644-d554-47dc-855d-4f399c3a0b0f" />


Now, transactions retain their native currency identity permanently, allowing multiple currencies to coexist correctly in the history list.