### PR TITLE
fix: Sidebar navigation freezes after 2-3 clicks (#74)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Dashboard from "./pages/Dashboard";
 import Budgets from "./pages/Budgets";
 import Settings from "./pages/Settings";
@@ -17,7 +17,7 @@ export default function App() {
           <BrowserRouter>
             <Routes>
               <Route path="/" element={<Layout />}>
-                <Route path="/" element={<Dashboard />} />
+                <Route index element={<Dashboard />} />
                 <Route path="budgets" element={<Budgets />} />
                 <Route path="settings" element={<Settings />} />
                 <Route path="transaction" element={<Transaction />} />

--- a/src/pages/Budgets.jsx
+++ b/src/pages/Budgets.jsx
@@ -44,7 +44,7 @@ export default function Budgets() {
     if (exceeded.length > 0) {
       setShowAlert(true);
     }
-  }, [budgets, transactions, spending]);
+  }, [budgets, transactions,]);
 
   const categories = Object.keys(spending || {});
 


### PR DESCRIPTION
Fixes #74

## Root Cause
In Budgets.jsx, the useEffect checking for exceeded budgets had `spending` in its dependency array. Since `spending` is recalculated on every render, this caused an infinite re-render loop that froze navigation after 2-3 tab switches.

## Changes Made
- Removed `spending` from useEffect dependency array in Budgets.jsx
- Changed nested Dashboard route from `path="/"` to `index` route in App.jsx
- Removed unused `Link` import from react-router-dom in App.jsx

## How to Test
1. Run `npm run dev`
2. Open `http://localhost:5173`
3. Click through all sidebar links repeatedly
4. Content should update instantly every time with no freezing