### PR TITLE
Pull Request: Add Category Support for Manual & Fixed Transactions

### DIFF
--- a/src/components/utils/categorize.js
+++ b/src/components/utils/categorize.js
@@ -1,12 +1,12 @@
 
   const keywords = {
-    Food : ["swiggy", "zomato", "blinkit", "bigbasket"],
-    Transport : ["uber", "ola", "rapido", "petrol"],
-    Income : ["salary", "freelance", "dividend"],
-    Entertainment : ["netflix", "youtube", "bookmyshow", "spotify"],
-    Shopping : ["amazon", "flipkart", "hm", "myntra"],
-    Bills : ["electricity", "water", "airtel", "rent"],
-    Health : ["medical", "pharmacy", "gym"]
+    Food : ["swiggy", "zomato", "blinkit", "bigbasket","Food"],
+    Transport : ["uber", "ola", "rapido", "petrol", "Transport"],
+    Income : ["salary", "freelance", "dividend","Income"],
+    Entertainment : ["netflix", "youtube", "bookmyshow", "spotify","Entertainment"],
+    Shopping : ["amazon", "flipkart", "hm", "myntra","Shopping"],
+    Bills : ["electricity", "water", "airtel", "rent","Bills"],
+    Health : ["medical", "pharmacy", "gym","Health"]
   }
 
 export default function categorize(description) {

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -7,13 +7,17 @@ import { useModal } from "../context/ModalContext";
 
 const categoryIcons = {
   Food: "🍔",
-  Travel: "✈️",
+  Transport: "✈️",
   Shopping: "🛒",
-  Salary: "💰",
+  Income: "💰",
   Bills: "📄",
   Entertainment: "🎬",
   Health: "🏥",
+  Other: "📌"
 };
+
+
+
 export default function CSVParser() {
   const {
     transactions,
@@ -27,6 +31,8 @@ export default function CSVParser() {
   const [data, setData] = useState([]);
   const [showManualEntry, setShowManualEntry] = useState(false);
   const [importMode, setImportMode] = useState("replace"); // 'replace' or 'append'
+  const [DEFAULTCATEGORIES , setDEFAULTCATEGORIES] = useState([ "select","Food", "Transport",
+  "Shopping","Income", "Bills", "Entertainment", "Health", "Other"]);
 
   // Loading + Success states
   const [loading, setLoading] = useState(false);
@@ -115,7 +121,8 @@ export default function CSVParser() {
 
     if (
       !manualTransaction.Description ||
-      !manualTransaction.Amount
+      !manualTransaction.Amount ||
+      !manualTransaction.category
     ) {
       showModal({ type: 'alert', message: "Please fill in all fields" });
       return;
@@ -125,6 +132,7 @@ export default function CSVParser() {
       Date: manualTransaction.Date,
       Description: manualTransaction.Description,
       Amount: manualTransaction.Amount,
+      category: manualTransaction.category,
       Currency: currency,
     };
 
@@ -144,6 +152,7 @@ export default function CSVParser() {
       Date: format(new Date(), "dd/MM/yyyy"),
       Description: "",
       Amount: "",
+      category:""
     });
 
     setSuccessMessage("Transaction added successfully!");
@@ -351,6 +360,27 @@ export default function CSVParser() {
                   className="retro-input p-3 w-full"
                   required
                 />
+              </div>
+
+              <div>
+                <label className="block text-xs text-gray-400 uppercase tracking-wider font-bold mb-2">
+                  Select Category
+                </label>
+                <select 
+                  className="retro-input p-3 w-full"
+                  onChange={(e) =>
+                    setManualTransaction({
+                      ...manualTransaction,
+                      category: e.target.value,
+                    })
+                  }
+                >
+                  {
+                    DEFAULTCATEGORIES.map((options, index)=>(
+                      <option key={index} value={options}>{options}</option>
+                    ))
+                  }
+                </select>
               </div>
 
               <div>

--- a/src/pages/Transaction.jsx
+++ b/src/pages/Transaction.jsx
@@ -4,15 +4,17 @@ import { DataContext } from "../context/AppContext";
 import { useModal } from "../context/ModalContext";
 import categorize from "../components/utils/categorize";
 import { parse } from "date-fns";
+import { useState } from "react";
 
 const categoryIcons = {
-  FOOD: "🍔",
-  TRANSPORT: "✈️",
-  SHOPPING: "🛒",
-  INCOME: "💰",
-  BILLS: "📄",
-  HEALTH: "🏥",
-  OTHER: "📌",
+  Food: "🍔",
+  Transport: "✈️",
+  Shopping: "🛒",
+  Income: "💰",
+  Bills: "📄",
+  Entertainment: "🎬",
+  Health: "🏥",
+  Other: "📌",
 };
 
 function EditModal({ transaction, onSave, onClose }) {
@@ -20,7 +22,11 @@ function EditModal({ transaction, onSave, onClose }) {
     Date: transaction.Date,
     Description: transaction.Description,
     Amount: transaction.Amount,
+    category: transaction.category || "",
   });
+
+  const [DEFAULTCATEGORIES , setDEFAULTCATEGORIES] = useState([ "Food", "Transport",
+    "Shopping","Income", "Bills", "Entertainment", "Health", "Other"]);
 
   const handleChange = (e) => {
     setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
@@ -63,6 +69,23 @@ function EditModal({ transaction, onSave, onClose }) {
               onChange={handleChange}
               className="retro-input p-3 w-full"
             />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 uppercase tracking-wider font-bold mb-2">
+              Select Category
+            </label>
+            <select 
+              className="retro-input p-3 w-full"
+              name="category"
+              value={form.category}
+              onChange={handleChange}
+              >
+              {
+                DEFAULTCATEGORIES.map((options, index)=>(
+                  <option key={index} value={options}>{options}</option>
+                ))
+              }
+            </select>
           </div>
           <div>
             <label className="block text-xs text-gray-400 uppercase tracking-wider font-bold mb-2">
@@ -110,7 +133,7 @@ export default function Transaction() {
 
   const allCategories = React.useMemo(() => {
     const cats = new Set();
-    transactions?.forEach((t) => cats.add(categorize(t.Description)));
+    transactions?.forEach((t) => cats.add(t.category || categorize(t.Description)));
     return Array.from(cats).sort();
   }, [transactions]);
 
@@ -176,7 +199,7 @@ export default function Transaction() {
 
     if (selectedCategories.length > 0) {
       indexed = indexed.filter(({ t }) =>
-        selectedCategories.includes(categorize(t.Description))
+        selectedCategories.includes(t.category || categorize(t.Description))
       );
     }
 
@@ -200,7 +223,7 @@ export default function Transaction() {
         case "amount-desc":
           return Number(b.t.Amount) - Number(a.t.Amount);
         case "category":
-          return categorize(a.t.Description).localeCompare(categorize(b.t.Description));
+          return (a.t.category || categorize(a.t.Description)).localeCompare(b.t.category || categorize(b.t.Description));
         default:
           return 0;
       }
@@ -255,7 +278,7 @@ export default function Transaction() {
       item.Date,
       item.Description,
       item.Amount,
-      categorize(item.Description),
+      item.category || categorize(item.Description),
     ]);
     const csvContent = [headers.join(","), ...rows.map((row) => row.join(","))].join("\n");
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
@@ -444,8 +467,8 @@ export default function Transaction() {
                 </td>
                 <td className="py-4 px-6">
                   <span className="bg-[#1F1F1F] text-gray-300 px-3 py-1 text-xs font-bold uppercase tracking-wider rounded-sm border border-[#2a2a2a] flex items-center gap-2 w-fit">
-                    <span>{categoryIcons[categorize(data.Description)] || "📌"}</span>
-                    {categorize(data.Description)}
+                    <span>{categoryIcons[data.category] || categoryIcons[categorize(data.Description)] || "📌"}</span>
+                    {data.category || categorize(data.Description)}
                   </span>
                 </td>
                 <td className="py-4 px-6">


### PR DESCRIPTION
 ### **Issue:**
The manual transaction form is missing a category input field. Currently, categories are only identified through mock data  users cannot select or assign a category when adding a transaction manually.

Additionally Fixed transaction pages as well 
In upcoming feature I will try to implement unit tests.

Are there any changes? 