### PR TITLE
fix: remove unused categoryIcons dead code from Settings.jsx

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -5,15 +5,6 @@ import { demoData } from "../data/demoData";
 import { format } from "date-fns";
 import { useModal } from "../context/ModalContext";
 
-const categoryIcons = {
-  Food: "🍔",
-  Travel: "✈️",
-  Shopping: "🛒",
-  Salary: "💰",
-  Bills: "📄",
-  Entertainment: "🎬",
-  Health: "🏥",
-};
 export default function CSVParser() {
   const {
     transactions,


### PR DESCRIPTION
## 🐛 Bug Fix — Remove Dead Code

Fixes #102 

## Problem
The `categoryIcons` object was defined in `Settings.jsx` 
but never used anywhere in the component, causing an 
ESLint `no-unused-vars` warning.

## Fix
Removed the unused `categoryIcons` object entirely.

## Files Changed
- `src/pages/Settings.jsx`

## Type of Change
- [x] Bug fix / Code cleanup

close #102 