### PR TITLE
[FEATURE] Add "Quick Add Transaction" FAB directly on the Dashboard

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -29,6 +29,12 @@ export function AppContext({ children }) {
     localStorage.setItem('transactions', JSON.stringify(updated));
   };
 
+  const addTransaction = (newTransaction) => {
+    const updated = [...(transactions || []), newTransaction];
+    setTransactions(updated);
+    localStorage.setItem('transactions', JSON.stringify(updated));
+  };
+
   const updateTransaction = (index, updatedTransaction) => {
     const updated = transactions.map((t, i) => (i === index ? updatedTransaction : t));
     setTransactions(updated);
@@ -36,7 +42,7 @@ export function AppContext({ children }) {
   };
 
   return (
-    <DataContext.Provider value={{ transactions, setTransactions, currency, updateCurrency, deleteTransaction, updateTransaction }}>
+    <DataContext.Provider value={{ transactions, setTransactions, currency, updateCurrency, deleteTransaction, updateTransaction, addTransaction}}>
       {children}
     </DataContext.Provider>
   );

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -15,12 +15,41 @@ import {
 } from "recharts";
 import React from "react";
 import { parse, format } from "date-fns";
-import { TrendingUp, TrendingDown, PiggyBank } from "lucide-react";
+import { TrendingUp, TrendingDown, PiggyBank, Plus, X } from "lucide-react";
 
 export default function Dashboard() {
-  const { transactions, currency } = React.useContext(DataContext);
+  const { transactions, currency, addTransaction} = React.useContext(DataContext);
 
   const [loading] = React.useState(false);
+  const [showForm, setShowForm] = React.useState(false);
+  const [successMsg, setSuccessMsg] = React.useState("");
+  const [form, setForm] = React.useState({
+    Date: format(new Date(), "dd/MM/yyyy"),
+    Description: "",
+    Amount: "",
+  });
+
+  const handleQuickAdd = (e) => {
+    e.preventDefault();
+    if (!form.Description || !form.Amount) return;
+    if (Number(form.Amount) === 0) return;
+
+    addTransaction({
+      Date: form.Date,
+      Description: form.Description,
+      Amount: form.Amount,
+      Currency: currency,
+    });
+
+    setForm({
+      Date: format(new Date(), "dd/MM/yyyy"),
+      Description: "",
+      Amount: "",
+    });
+
+    setSuccessMsg("Transaction added!");
+    setTimeout(() => setSuccessMsg(""), 3000);
+  };
 
   const COLORS = [
     "#0088FE",
@@ -90,167 +119,222 @@ export default function Dashboard() {
 
   const barData = Object.values(monthData || {});
 
-  return (
-    <div className="space-y-8 animate-in fade-in duration-500">
-      {loading && (
-        <div className="flex justify-center items-center py-10">
-          <span className="loading loading-spinner loading-lg text-primary"></span>
-        </div>
-      )}
-
-      {transactions && transactions.length > 0 ? (
-        <>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-stretch">
-            <div className="fin-metric-card h-full animate-in fade-in duration-500">
-              <div className="flex items-center justify-between mb-4">
-                <div>
-                  <p className="text-xs font-bold tracking-widest uppercase text-gray-500 mb-1">
-                    Income
-                  </p>
-                  <p className="text-[#00C49F] text-3xl font-black">
-                    {currency.symbol}
-                    {totalIncome.toLocaleString()}
-                  </p>
-                </div>
-                <div
-                  className="p-3 rounded-xl"
-                  style={{
-                    background: "rgba(0,196,159,0.1)",
-                    border: "1px solid rgba(0,196,159,0.2)",
-                  }}
-                >
-                  <TrendingUp className="w-5 h-5 text-[#00C49F]" />
-                </div>
-              </div>
-              <p className="text-xs text-gray-600">Total income received</p>
-            </div>
-
-            <div className="fin-metric-card h-full animate-in fade-in duration-500">
-              <div className="flex items-center justify-between mb-4">
-                <div>
-                  <p className="text-xs font-bold tracking-widest uppercase text-gray-500 mb-1">
-                    Spent
-                  </p>
-                  <p className="text-[#FF6B6B] text-3xl font-black">
-                    {currency.symbol}
-                    {Math.abs(totalExpense).toLocaleString()}
-                  </p>
-                </div>
-                <div
-                  className="p-3 rounded-xl"
-                  style={{
-                    background: "rgba(255,107,107,0.1)",
-                    border: "1px solid rgba(255,107,107,0.2)",
-                  }}
-                >
-                  <TrendingDown className="w-5 h-5 text-[#FF6B6B]" />
-                </div>
-              </div>
-              <p className="text-xs text-gray-600">Total expenses tracked</p>
-            </div>
-
-            <div className="fin-metric-card h-full animate-in fade-in duration-500">
-              <div className="flex items-center justify-between mb-4">
-                <div>
-                  <p className="text-xs font-bold tracking-widest uppercase text-gray-500 mb-1">
-                    Savings
-                  </p>
-                  <p className="text-[#0088FE] text-3xl font-black">
-                    {currency.symbol}
-                    {savings.toLocaleString()}
-                  </p>
-                </div>
-                <div
-                  className="p-3 rounded-xl"
-                  style={{
-                    background: "rgba(0,136,254,0.1)",
-                    border: "1px solid rgba(0,136,254,0.2)",
-                  }}
-                >
-                  <PiggyBank className="w-5 h-5 text-[#0088FE]" />
-                </div>
-              </div>
-              <p className="text-xs text-gray-600">Net savings balance</p>
-            </div>
+return (
+    <>
+      <div className="space-y-8 animate-in fade-in duration-500">
+        {loading && (
+          <div className="flex justify-center items-center py-10">
+            <span className="loading loading-spinner loading-lg text-primary"></span>
           </div>
+        )}
 
-          <section className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-stretch">
-            <div className="retro-card p-4 flex flex-col items-center justify-center min-h-[400px] h-full animate-in fade-in duration-500">
-              <h3 className="text-fin-orange font-bold tracking-widest text-sm uppercase self-start mb-4 px-4 pt-2">
-                Spending by Category
-              </h3>
-
-              <ResponsiveContainer width="100%" height={350}>
-                <PieChart>
-                  <Pie
-                    data={chartData}
-                    innerRadius={90}
-                    outerRadius={130}
-                    dataKey="value"
-                    stroke="none"
+        {transactions && transactions.length > 0 ? (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-stretch">
+              <div className="fin-metric-card h-full animate-in fade-in duration-500">
+                <div className="flex items-center justify-between mb-4">
+                  <div>
+                    <p className="text-xs font-bold tracking-widest uppercase text-gray-500 mb-1">
+                      Income
+                    </p>
+                    <p className="text-[#00C49F] text-3xl font-black">
+                      {currency.symbol}
+                      {totalIncome.toLocaleString()}
+                    </p>
+                  </div>
+                  <div
+                    className="p-3 rounded-xl"
+                    style={{
+                      background: "rgba(0,196,159,0.1)",
+                      border: "1px solid rgba(0,196,159,0.2)",
+                    }}
                   >
-                    {chartData.map((entry, index) => (
-                      <Cell key={index} fill={COLORS[index % COLORS.length]} />
-                    ))}
-                  </Pie>
+                    <TrendingUp className="w-5 h-5 text-[#00C49F]" />
+                  </div>
+                </div>
+                <p className="text-xs text-gray-600">Total income received</p>
+              </div>
 
-                  <Tooltip />
-                  <Legend />
-                </PieChart>
-              </ResponsiveContainer>
+              <div className="fin-metric-card h-full animate-in fade-in duration-500">
+                <div className="flex items-center justify-between mb-4">
+                  <div>
+                    <p className="text-xs font-bold tracking-widest uppercase text-gray-500 mb-1">
+                      Spent
+                    </p>
+                    <p className="text-[#FF6B6B] text-3xl font-black">
+                      {currency.symbol}
+                      {Math.abs(totalExpense).toLocaleString()}
+                    </p>
+                  </div>
+                  <div
+                    className="p-3 rounded-xl"
+                    style={{
+                      background: "rgba(255,107,107,0.1)",
+                      border: "1px solid rgba(255,107,107,0.2)",
+                    }}
+                  >
+                    <TrendingDown className="w-5 h-5 text-[#FF6B6B]" />
+                  </div>
+                </div>
+                <p className="text-xs text-gray-600">Total expenses tracked</p>
+              </div>
+
+              <div className="fin-metric-card h-full animate-in fade-in duration-500">
+                <div className="flex items-center justify-between mb-4">
+                  <div>
+                    <p className="text-xs font-bold tracking-widest uppercase text-gray-500 mb-1">
+                      Savings
+                    </p>
+                    <p className="text-[#0088FE] text-3xl font-black">
+                      {currency.symbol}
+                      {savings.toLocaleString()}
+                    </p>
+                  </div>
+                  <div
+                    className="p-3 rounded-xl"
+                    style={{
+                      background: "rgba(0,136,254,0.1)",
+                      border: "1px solid rgba(0,136,254,0.2)",
+                    }}
+                  >
+                    <PiggyBank className="w-5 h-5 text-[#0088FE]" />
+                  </div>
+                </div>
+                <p className="text-xs text-gray-600">Net savings balance</p>
+              </div>
             </div>
 
-            <div className="retro-card p-4 flex flex-col min-h-[400px] h-full animate-in fade-in duration-500">
-              <h3 className="text-fin-orange font-bold tracking-widest text-sm uppercase self-start mb-4 px-4 pt-2">
-                Monthly Overview
-              </h3>
+            <section className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-stretch">
+              <div className="retro-card p-4 flex flex-col items-center justify-center min-h-[400px] h-full animate-in fade-in duration-500">
+                <h3 className="text-fin-orange font-bold tracking-widest text-sm uppercase self-start mb-4 px-4 pt-2">
+                  Spending by Category
+                </h3>
+                <ResponsiveContainer width="100%" height={350}>
+                  <PieChart>
+                    <Pie
+                      data={chartData}
+                      innerRadius={90}
+                      outerRadius={130}
+                      dataKey="value"
+                      stroke="none"
+                    >
+                      {chartData.map((entry, index) => (
+                        <Cell key={index} fill={COLORS[index % COLORS.length]} />
+                      ))}
+                    </Pie>
+                    <Tooltip />
+                    <Legend />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
 
-              <ResponsiveContainer width="100%" height={350}>
-                <BarChart data={barData}>
-                  <XAxis dataKey="month" />
-                  <YAxis />
-                  <Tooltip />
-                  <Legend />
-                  <Bar dataKey="income" fill="#00C49F" />
-                  <Bar dataKey="spent" fill="#FF6B6B" />
-                </BarChart>
-              </ResponsiveContainer>
+              <div className="retro-card p-4 flex flex-col min-h-[400px] h-full animate-in fade-in duration-500">
+                <h3 className="text-fin-orange font-bold tracking-widest text-sm uppercase self-start mb-4 px-4 pt-2">
+                  Monthly Overview
+                </h3>
+                <ResponsiveContainer width="100%" height={350}>
+                  <BarChart data={barData}>
+                    <XAxis dataKey="month" />
+                    <YAxis />
+                    <Tooltip />
+                    <Legend />
+                    <Bar dataKey="income" fill="#00C49F" />
+                    <Bar dataKey="spent" fill="#FF6B6B" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </section>
+          </>
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full min-h-[78vh] pt-10 animate-in fade-in duration-500">
+            <div className="retro-card p-12 flex flex-col items-center max-w-md text-center border-[#FF6B00]/30 shadow-[0_0_20px_rgba(255,107,0,0.1)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_24px_rgba(255,107,0,0.12)]">
+              <div className="w-16 h-16 bg-[#FF6B00]/10 flex items-center justify-center rounded-full mb-6 text-[#FF6B00]">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="32"
+                  height="32"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                </svg>
+              </div>
+              <h2 className="text-2xl font-black tracking-wider text-white mb-2 uppercase">
+                No Data Found
+              </h2>
+              <p className="text-gray-400 mb-8 leading-relaxed min-h-[88px] flex items-center justify-center">
+                Upload your transaction history from settings to start tracking your finances.
+              </p>
+              <Link to="/settings" className="retro-btn">
+                Configure Settings
+              </Link>
             </div>
-          </section>
-        </>
-      ) : (
-        <div className="flex flex-col items-center justify-center h-full min-h-[78vh] pt-10 animate-in fade-in duration-500">
-          <div className="retro-card p-12 flex flex-col items-center max-w-md text-center border-[#FF6B00]/30 shadow-[0_0_20px_rgba(255,107,0,0.1)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_24px_rgba(255,107,0,0.12)]">
-            <div className="w-16 h-16 bg-[#FF6B00]/10 flex items-center justify-center rounded-full mb-6 text-[#FF6B00]">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="32"
-                height="32"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
-              </svg>
-            </div>
+          </div>
+        )}
+      </div>
 
-            <h2 className="text-2xl font-black tracking-wider text-white mb-2 uppercase">
-              No Data Found
-            </h2>
+      {/* Floating Action Button */}
+      <button
+        onClick={() => setShowForm(!showForm)}
+        className="fixed bottom-8 right-8 z-50 w-14 h-14 rounded-full bg-[#FF6B00] text-white flex items-center justify-center shadow-lg hover:bg-[#e05e00] transition-all duration-200 hover:scale-110"
+      >
+        {showForm ? <X className="w-6 h-6" /> : <Plus className="w-6 h-6" />}
+      </button>
 
-            <p className="text-gray-400 mb-8 leading-relaxed min-h-[88px] flex items-center justify-center">
-              Upload your transaction history from settings to start tracking your finances.
-            </p>
-
-            <Link to="/settings" className="retro-btn">
-              Configure Settings
-            </Link>
+      {/* Modal Form */}
+      {showForm && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/60">
+          <div className="retro-card p-6 w-full max-w-md mx-4 animate-in fade-in duration-200">
+            <h3 className="text-fin-orange font-bold tracking-widest text-sm uppercase mb-4">
+              Quick Add Transaction
+            </h3>
+            <form onSubmit={handleQuickAdd} className="flex flex-col gap-3">
+              <input
+                type="date"
+                className="retro-input p-3 w-full"
+                onChange={(e) => {
+                  const [year, month, day] = e.target.value.split("-");
+                  setForm({ ...form, Date: `${day}/${month}/${year}` });
+                }}
+                defaultValue={format(new Date(), "yyyy-MM-dd")}
+              />
+              <input
+                type="text"
+                placeholder="Description e.g. Swiggy"
+                className="retro-input p-3 w-full"
+                value={form.Description}
+                onChange={(e) => setForm({ ...form, Description: e.target.value })}
+              />
+              <input
+                type="number"
+                placeholder="-450 (expense) or 5000 (income)"
+                className="retro-input p-3 w-full"
+                value={form.Amount}
+                onChange={(e) => setForm({ ...form, Amount: e.target.value })}
+              />
+              {successMsg && (
+                <p className="text-green-400 text-xs">{successMsg}</p>
+              )}
+              <div className="flex gap-3 mt-2">
+                <button type="submit" className="retro-btn flex-1">
+                  Add
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowForm(false)}
+                  className="flex-1 px-4 py-2 border border-gray-600 text-gray-400 hover:text-white transition-colors font-bold uppercase tracking-wider text-sm"
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -297,10 +297,11 @@ return (
                 type="date"
                 className="retro-input p-3 w-full"
                 onChange={(e) => {
+                  if (!e.target.value) return;
                   const [year, month, day] = e.target.value.split("-");
                   setForm({ ...form, Date: `${day}/${month}/${year}` });
                 }}
-                defaultValue={format(new Date(), "yyyy-MM-dd")}
+                value={form.Date.split("/").reverse().join("-")}
               />
               <input
                 type="text"

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -11,6 +11,7 @@ export default function CSVParser() {
     setTransactions,
     currency,
     updateCurrency,
+    addTransaction
   } = useContext(DataContext);
 
   const { showModal } = useModal();
@@ -123,17 +124,7 @@ export default function CSVParser() {
       Currency: currency,
     };
 
-    const updatedTransactions = [
-      ...(transactions || []),
-      newTransaction,
-    ];
-
-    setTransactions(updatedTransactions);
-
-    localStorage.setItem(
-      "transactions",
-      JSON.stringify(updatedTransactions)
-    );
+    addTransaction(newTransaction);
 
     setManualTransaction({
       Date: format(new Date(), "dd/MM/yyyy"),


### PR DESCRIPTION
## Description
Adds a floating action button (FAB) on the Dashboard so users can log transactions without navigating to Settings. Clicking the orange + button at the bottom-right opens a centered modal form. Also refactors the addTransaction logic into a shared function in AppContext so both Dashboard and Settings reuse the same code without duplication.

## Changes
- `AppContext.jsx` — added shared `addTransaction` function exposed via context
- `Dashboard.jsx` — added floating action button (FAB) at bottom-right that opens a centered modal form for quick transaction entry
- `Settings.jsx` — replaced manual `setTransactions` + `localStorage` logic with shared `addTransaction` from context

## Screenshots
<img width="1512" height="908" alt="image" src="https://github.com/user-attachments/assets/c6d09501-dcd1-409c-8698-35b743f38868" />
<img width="1512" height="906" alt="image" src="https://github.com/user-attachments/assets/7dd52f92-a8a3-4c46-9de1-6fe379011c18" />


## Related Issue
Closes #94

## Type of Contribution
- [x] New feature
- [x] Refactor

## Participant Info
- GitHub username: Kr1491
- Contribution level: Intermediate