### PR TITLE
fix: convert transaction amounts on currency switch using live exchan…

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 export const DataContext = React.createContext();
 
 export const CURRENCIES = [
@@ -17,10 +18,70 @@ export function AppContext({ children }) {
   const [currency, setCurrency] = React.useState(
     JSON.parse(localStorage.getItem('currency')) || CURRENCIES[0]
   );
+  const [converting, setConverting] = React.useState(false);
+  const [currencySymbols, setCurrencySymbols] = React.useState({});
 
-  const updateCurrency = (selectedCurrency) => {
-    setCurrency(selectedCurrency);
-    localStorage.setItem('currency', JSON.stringify(selectedCurrency));
+  React.useEffect(() => {
+    fetch('https://open.er-api.com/v6/latest/USD')
+      .then(res => res.json())
+      .then(data => {
+        const symbols = {};
+        Object.keys(data.rates).forEach(code => {
+          try {
+            const formatted = new Intl.NumberFormat('en', {
+              style: 'currency',
+              currency: code,
+              minimumFractionDigits: 0,
+            }).format(0);
+            symbols[code] = formatted.replace(/[\d,.\s]/g, '').trim();
+          } catch {
+            symbols[code] = code;
+          }
+        });
+        setCurrencySymbols(symbols);
+      })
+      .catch(err => console.error(err));
+  }, []);
+
+  const updateCurrency = async (selectedCurrency) => {
+    if (selectedCurrency.code === currency.code) return;
+
+    const confirmed = window.confirm(
+      `Convert all transactions from ${currency.code} to ${selectedCurrency.code}?`
+    );
+    if (!confirmed) return;
+
+    setConverting(true);
+
+    try {
+      const res = await fetch(
+        `https://open.er-api.com/v6/latest/${currency.code}`
+      );
+      const data = await res.json();
+      const rate = data.rates[selectedCurrency.code];
+
+      if (!rate) throw new Error('Rate not found');
+
+      const enrichedCurrency = {
+        ...selectedCurrency,
+        symbol: currencySymbols[selectedCurrency.code] || selectedCurrency.symbol,
+      };
+
+      const convertedTransactions = transactions.map((t) => ({
+        ...t,
+        Amount: (Number(t.Amount) * rate).toFixed(2),
+      }));
+
+      setTransactions(convertedTransactions);
+      localStorage.setItem('transactions', JSON.stringify(convertedTransactions));
+      setCurrency(enrichedCurrency);
+      localStorage.setItem('currency', JSON.stringify(enrichedCurrency));
+    } catch (err) {
+      alert('Failed to fetch exchange rate. Check your internet and try again.');
+      console.error(err);
+    } finally {
+      setConverting(false);
+    }
   };
 
   const deleteTransaction = (index) => {
@@ -36,7 +97,27 @@ export function AppContext({ children }) {
   };
 
   return (
-    <DataContext.Provider value={{ transactions, setTransactions, currency, updateCurrency, deleteTransaction, updateTransaction }}>
+    <DataContext.Provider value={{
+      transactions,
+      setTransactions,
+      currency,
+      updateCurrency,
+      deleteTransaction,
+      updateTransaction,
+      converting,
+    }}>
+      {converting && (
+        <div style={{
+          position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+          background: 'rgba(0,0,0,0.7)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          zIndex: 9999,
+        }}>
+          <div style={{ color: '#FF6B00', fontSize: '1.2rem', fontWeight: 'bold' }}>
+            Converting transactions... please wait
+          </div>
+        </div>
+      )}
       {children}
     </DataContext.Provider>
   );


### PR DESCRIPTION
 Fixes #99

## Problem
When switching currency in Settings, the app was only updating the currency symbol while keeping the raw transaction amounts unchanged. This caused incorrect financial data across Dashboard, Budgets, Transactions, and Insights pages.

## Root Cause
In `AppContext.jsx`, the `updateCurrency` function was only saving the new currency object to state and localStorage without applying any exchange rate conversion to existing transaction amounts.

## Solution
- Replaced the symbol-only swap with a live exchange rate fetch using `open.er-api.com` (free, no API key required, CORS supported)
- All existing transaction `Amount` values are now multiplied by the live exchange rate on currency switch
- Added a confirmation dialog before converting so users don't accidentally trigger it
- Added a loading overlay while conversion is in progress
- Currency symbols are now fetched dynamically using `Intl.NumberFormat` so any future currency added to the `CURRENCIES` array works automatically without hardcoding symbols

## Changes
- `src/context/AppContext.jsx` — only file changed

## Testing
- Loaded demo data in Settings
- Noted amounts on Dashboard (e.g. ₹5000)
- Switched currency to USD
- Confirmed amounts correctly converted (₹5000 → $52.52) using live rate 

## API Used
- https://open.er-api.com (free, no API key, CORS friendly)
