### PR TITLE
fix: Add Income/Expense toggle to manual transaction form — replace hidden negative sign convention

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -111,6 +111,7 @@ export function AppContext({ children }) {
       deleteTransaction,
       updateTransaction,
       converting,
+      addTransaction,
     }}>
       {converting && (
         <div style={{

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -123,7 +123,6 @@ export function AppContext({ children }) {
       addTransaction,
       updateTransaction,
       converting,
-      addTransaction,
     }}>
       {converting && (
         <div style={{

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -28,7 +28,7 @@ export default function Dashboard() {
     Description: "",
     Amount: "",
   });
-
+  const [transactionType, setTransactionType] = React.useState("expense");
   const handleQuickAdd = (e) => {
     e.preventDefault();
     if (!form.Description || !form.Amount) return;
@@ -37,7 +37,9 @@ export default function Dashboard() {
     addTransaction({
       Date: form.Date,
       Description: form.Description,
-      Amount: form.Amount,
+      Amount: transactionType === "expense"
+        ? -Math.abs(Number(form.Amount))
+        : Math.abs(Number(form.Amount)),
       Currency: currency,
     });
 
@@ -310,9 +312,33 @@ return (
                 value={form.Description}
                 onChange={(e) => setForm({ ...form, Description: e.target.value })}
               />
+              <div className="flex rounded-xl overflow-hidden border border-[#222]">
+                <button
+                  type="button"
+                  onClick={() => setTransactionType("expense")}
+                  className={`flex-1 py-3 text-sm font-bold uppercase tracking-wider transition-colors ${
+                    transactionType === "expense"
+                      ? "bg-[#FF6B6B] text-white"
+                      : "bg-[#111] text-gray-400 hover:text-white"
+                  }`}
+                >
+                  Expense
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setTransactionType("income")}
+                  className={`flex-1 py-3 text-sm font-bold uppercase tracking-wider transition-colors ${
+                    transactionType === "income"
+                      ? "bg-[#00C49F] text-white"
+                      : "bg-[#111] text-gray-400 hover:text-white"
+                  }`}
+                >
+                  Income
+                </button>
+              </div>
               <input
                 type="number"
-                placeholder="-450 (expense) or 5000 (income)"
+                placeholder="e.g., 450"
                 className="retro-input p-3 w-full"
                 value={form.Amount}
                 onChange={(e) => setForm({ ...form, Amount: e.target.value })}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -60,7 +60,7 @@ export default function Settings() {
   const [importMode, setImportMode] = useState("replace");
   const [loading, setLoading] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
-
+  const [transactionType, setTransactionType] = useState("expense");
   const [manualTransaction, setManualTransaction] = useState({
     Date: format(new Date(), "dd/MM/yyyy"),
     Description: "",
@@ -159,8 +159,10 @@ export default function Settings() {
     const newTransaction = {
       Date: manualTransaction.Date,
       Description: manualTransaction.Description,
-      Amount: manualTransaction.Amount,
-      category: manualTransaction.category,
+      Amount: transactionType === "expense"
+        ? -Math.abs(Number(manualTransaction.Amount))
+        : Math.abs(Number(manualTransaction.Amount)),
+      Category: manualTransaction.category,
       Currency: currency,
     };
 
@@ -342,7 +344,37 @@ export default function Settings() {
                 />
               </div>
 
-              {/* AMOUNT — Fix: step="0.01" added back for decimal support */}
+              {/* AMOUNT with Income/Expense toggle */}
+              <div className="space-y-2">
+                <label className="text-xs font-bold uppercase text-gray-500">
+                  Type
+                </label>
+                <div className="flex rounded-xl overflow-hidden border border-[#222]">
+                  <button
+                    type="button"
+                    onClick={() => setTransactionType("expense")}
+                    className={`flex-1 py-3 text-sm font-bold uppercase tracking-wider transition-colors ${
+                      transactionType === "expense"
+                        ? "bg-[#FF6B6B] text-white"
+                        : "bg-[#111] text-gray-400 hover:text-white"
+                    }`}
+                  >
+                    Expense
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setTransactionType("income")}
+                    className={`flex-1 py-3 text-sm font-bold uppercase tracking-wider transition-colors ${
+                      transactionType === "income"
+                        ? "bg-[#00C49F] text-white"
+                        : "bg-[#111] text-gray-400 hover:text-white"
+                    }`}
+                  >
+                    Income
+                  </button>
+                </div>
+              </div>
+
               <div className="space-y-2">
                 <label className="text-xs font-bold uppercase text-gray-500">
                   Amount
@@ -351,7 +383,8 @@ export default function Settings() {
                   type="number"
                   required
                   step="0.01"
-                  placeholder="e.g., -450 or 5000"
+                  min="0.01"
+                  placeholder="e.g., 450"
                   value={manualTransaction.Amount}
                   onChange={(e) =>
                     setManualTransaction({


### PR DESCRIPTION
## Description
Replaces the hidden negative/positive sign convention in the manual transaction form with an explicit Income/Expense toggle. Users no longer need to know that negative = expense and positive = income — the app now handles the sign automatically based on the toggle selection. This fix has been applied consistently across both the Settings page and the Dashboard FAB modal.

## Changes
- `Settings.jsx` — replaced single Amount field with an Income/Expense sliding toggle + positive-only Amount input. Sign is applied automatically on submit.
- `Dashboard.jsx` — same Income/Expense toggle added to the Quick Add FAB modal for consistency, so users get the same clear experience regardless of where they add a transaction.
- `AppContext.jsx` — exposed `addTransaction` in the Provider value so both Settings and Dashboard can use the shared function.
## Screenshots
<img width="1512" height="906" alt="image" src="https://github.com/user-attachments/assets/8b76374f-3e36-49be-8435-d79668dad200" />
<img width="1512" height="905" alt="image" src="https://github.com/user-attachments/assets/1d0a2840-ac19-4cb6-90ec-7cc7b3637d8c" />

## Related Issue
Closes #95 

## Type of Contribution
- [x] Bug fix
- [x] Refactor

## Participant Info
- GitHub username: @Kr1491 
- Contribution level: Intermediate