### PR TITLE
docs: add MIT LICENSE and reference it in README and CONTRIBUTING

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 khanirfan18
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Closes #132 

## What this PR does
Adds a MIT `LICENSE` file at the project root and updates `README.md` and `CONTRIBUTING.md` to reference it. No code or config files were changed.

## Changes
- `LICENSE` — new file (MIT)
- `README.md` — added license badge and `## License` section
- `CONTRIBUTING.md` — added license section and security reporting note

## Acceptance criteria checklist
- [x] `LICENSE` exists at project root
- [x] GitHub sidebar will auto-display MIT license
- [x] `README.md` references the license (badge + section)
- [x] `CONTRIBUTING.md` notes what license contributions fall under
- [x] Zero changes to any existing code or config files