### PR TITLE
feat(theme): add light/dark mode support with persistent theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Layout from "./components/layout/Layout";
 import { AppContext } from "./context/AppContext";
 import { AuthProvider } from "./context/AuthContext";
 import { ModalProvider } from "./context/ModalContext";
+import { ThemeProvider } from "./context/ThemeContext";
 import Modal from "./components/Modal";
 import ProtectedRoute from "./components/ProtectedRoute";
 import GuestRoute from "./components/GuestRoute";
@@ -18,52 +19,54 @@ import ResetPassword from "./pages/ResetPassword";
 export default function App() {
   return (
     <>
-      <AuthProvider>
-        <AppContext>
-          <ModalProvider>
-            <BrowserRouter>
-              <Routes>
-                {/* ── Public auth routes  */}
-                <Route
-                  path="/signin"
-                  element={
-                    <GuestRoute>
-                      <SignIn />
-                    </GuestRoute>
-                  }
-                />
-                <Route
-                  path="/signup"
-                  element={
-                    <GuestRoute>
-                      <SignUp />
-                    </GuestRoute>
-                  }
-                />
-                <Route path="/reset-password" element={<ResetPassword />} />
+      <ThemeProvider>
+        <AuthProvider>
+          <AppContext>
+            <ModalProvider>
+              <BrowserRouter>
+                <Routes>
+                  {/* ── Public auth routes  */}
+                  <Route
+                    path="/signin"
+                    element={
+                      <GuestRoute>
+                        <SignIn />
+                      </GuestRoute>
+                    }
+                  />
+                  <Route
+                    path="/signup"
+                    element={
+                      <GuestRoute>
+                        <SignUp />
+                      </GuestRoute>
+                    }
+                  />
+                  <Route path="/reset-password" element={<ResetPassword />} />
 
-                {/* ── Protected routes  */}
-                <Route
-                  path="/"
-                  element={
-                    <ProtectedRoute>
-                      <Layout />
-                    </ProtectedRoute>
-                  }
-                >
-                  <Route index element={<Dashboard />} />
-                  <Route path="dashboard" element={<Dashboard />} />
-                  <Route path="budgets" element={<Budgets />} />
-                  <Route path="settings" element={<Settings />} />
-                  <Route path="transaction" element={<Transaction />} />
-                  <Route path="insights" element={<InsightsDashboard />} />
-                </Route>
-              </Routes>
-            </BrowserRouter>
-            <Modal />
-          </ModalProvider>
-        </AppContext>
-      </AuthProvider>
+                  {/* ── Protected routes  */}
+                  <Route
+                    path="/"
+                    element={
+                      <ProtectedRoute>
+                        <Layout />
+                      </ProtectedRoute>
+                    }
+                  >
+                    <Route index element={<Dashboard />} />
+                    <Route path="dashboard" element={<Dashboard />} />
+                    <Route path="budgets" element={<Budgets />} />
+                    <Route path="settings" element={<Settings />} />
+                    <Route path="transaction" element={<Transaction />} />
+                    <Route path="insights" element={<InsightsDashboard />} />
+                  </Route>
+                </Routes>
+              </BrowserRouter>
+              <Modal />
+            </ModalProvider>
+          </AppContext>
+        </AuthProvider>
+      </ThemeProvider>
     </>
   );
 }

--- a/src/components/GuestRoute.jsx
+++ b/src/components/GuestRoute.jsx
@@ -11,20 +11,20 @@ export default function GuestRoute({ children }) {
   if (loading) {
     return (
       <div
+        className="theme-route-loader"
         style={{
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
           height: '100vh',
-          background: '#080808',
         }}
       >
         <div
           style={{
             width: 40,
             height: 40,
-            border: '3px solid #222',
-            borderTopColor: '#FF6B00',
+            border: '3px solid var(--color-fin-border)',
+            borderTopColor: 'var(--color-fin-accent)',
             borderRadius: '50%',
             animation: 'spin 0.8s linear infinite',
           }}

--- a/src/components/Insights/CategoryBreakdown.jsx
+++ b/src/components/Insights/CategoryBreakdown.jsx
@@ -1,6 +1,9 @@
 import React from "react";
+import { useTheme } from "../../context/ThemeContext";
 
 export default function CategoryBreakdown({ transactions }) {
+  const { theme } = useTheme();
+
   const getCategoryStats = () => {
     const totals = {};
     let totalExpenseSum = 0;
@@ -32,14 +35,23 @@ export default function CategoryBreakdown({ transactions }) {
       }
     });
 
-    const colorMap = {
-      bills: "#ef4444",      // Coral Red
-      food: "#3b82f6",       // Indigo Blue
-      health: "#a855f7",     // Fuchsia Purple
-      shopping: "#ec4899",   // Hot Pink
-      transport: "#10b981",  // Teal Green
-      other: "#f59e0b",      // Amber Orange
-    };
+    const colorMap = theme === "light"
+      ? {
+          bills: "#8B5CF6",
+          food: "#A78BFA",
+          health: "#C4B5FD",
+          shopping: "#DDD6FE",
+          transport: "#EDE9FE",
+          other: "#F5F3FF",
+        }
+      : {
+          bills: "#ef4444",      // Coral Red
+          food: "#3b82f6",       // Indigo Blue
+          health: "#a855f7",     // Fuchsia Purple
+          shopping: "#ec4899",   // Hot Pink
+          transport: "#10b981",  // Teal Green
+          other: "#f59e0b",      // Amber Orange
+        };
 
     const formatLabel = (str) => str.charAt(0).toUpperCase() + str.slice(1);
 
@@ -59,7 +71,7 @@ export default function CategoryBreakdown({ transactions }) {
   const categories = getCategoryStats();
 
   return (
-    <div className="bg-[#121214] border border-zinc-800/80 rounded-xl p-6 h-full">
+    <div className="theme-panel rounded-xl p-6 h-full">
       <div className="mb-6">
         <h3 className="text-base font-bold text-white mb-1">Full Category Breakdown</h3>
         <p className="text-xs text-zinc-500">Ranked contribution distribution analysis</p>

--- a/src/components/Insights/InsightCards.jsx
+++ b/src/components/Insights/InsightCards.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { ShoppingBag, PiggyBank, TrendingUp, Target, Calendar, DollarSign } from 'lucide-react';
 import { parse, format } from 'date-fns';
+import { useTheme } from '../../context/ThemeContext';
 
 export default function InsightCards({ transactions }) {
+  const { theme } = useTheme();
   
   const processMetrics = () => {
     let income = 0;
@@ -21,7 +23,7 @@ export default function InsightCards({ transactions }) {
           // Parse "dd/MM/yyyy" format accurately using date-fns
           const parsedDate = parse(t.Date, "dd/MM/yyyy", new Date());
           monthYear = format(parsedDate, "MMM yyyy");
-        } catch (e) {
+        } catch {
           // Fallback parsing if date structure varies
           const fallbackDate = new Date(t.Date);
           if (!isNaN(fallbackDate.getTime())) {
@@ -94,45 +96,45 @@ export default function InsightCards({ transactions }) {
       title: "TOP SPENDING CATEGORY",
       value: metrics.topCategory,
       subtitle: `₹${metrics.topCatAmt.toLocaleString()} spent — your biggest expense bucket.`,
-      icon: <ShoppingBag className="w-5 h-5 text-blue-400" />,
+      icon: <ShoppingBag className="w-5 h-5" style={{ color: theme === 'light' ? '#8B5CF6' : '#60A5FA' }} />,
     },
     {
       title: "SAVINGS RATE",
       value: `${metrics.savingsRate}%`,
       subtitle: metrics.savingsRate >= 20 ? "Great job! You're saving above the recommended 20% threshold." : "Try reducing non-essential expenses to hit a 20% safety margin.",
-      icon: <PiggyBank className="w-5 h-5 text-pink-400" />,
+      icon: <PiggyBank className="w-5 h-5" style={{ color: theme === 'light' ? '#A78BFA' : '#F472B6' }} />,
     },
     {
       title: "MONTH-ON-MONTH EXPENSES",
       value: "+99%", 
       subtitle: "Spending rose vs February 2026. Review discretionary categories.",
-      icon: <TrendingUp className="w-5 h-5 text-red-400" />,
-      valueClass: "text-red-500"
+      icon: <TrendingUp className="w-5 h-5" style={{ color: theme === 'light' ? '#8B5CF6' : '#F87171' }} />,
+      valueClass: theme === 'light' ? 'text-[var(--color-fin-accent)]' : 'text-red-500'
     },
     {
       title: "NET SAVINGS THIS MONTH",
       value: `₹${metrics.netSavings.toLocaleString()}`,
       subtitle: `Income ₹${metrics.totalIncome.toLocaleString()} minus expenses ₹${metrics.totalExpenses.toLocaleString()}`,
-      icon: <Target className="w-5 h-5 text-fuchsia-400" />,
+      icon: <Target className="w-5 h-5" style={{ color: theme === 'light' ? '#8B5CF6' : '#E879F9' }} />,
     },
     {
       title: "MOST ACTIVE MONTH",
       value: metrics.mostActiveMonth,
       subtitle: "The month with the highest combined income and expense activity.",
-      icon: <Calendar className="w-5 h-5 text-emerald-400" />,
+      icon: <Calendar className="w-5 h-5" style={{ color: theme === 'light' ? '#8B5CF6' : '#34D399' }} />,
     },
     {
       title: "AVG MONTHLY INCOME",
       value: `₹${metrics.avgMonthlyIncome.toLocaleString()}`,
       subtitle: "Average income across all recorded months in your history.",
-      icon: <DollarSign className="w-5 h-5 text-purple-400" />,
+      icon: <DollarSign className="w-5 h-5" style={{ color: theme === 'light' ? '#8B5CF6' : '#C084FC' }} />,
     }
   ];
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
       {cardConfig.map((card, idx) => (
-        <div key={idx} className="bg-[#121214] border border-zinc-800/80 rounded-xl p-5 hover:border-zinc-700 transition duration-200 flex flex-col justify-between">
+        <div key={idx} className="theme-panel theme-panel-strong rounded-xl p-5 hover:border-zinc-700 transition duration-200 flex flex-col justify-between">
           <div>
             <div className="flex items-center justify-between mb-3">
               <span className="text-[11px] font-bold tracking-wider text-zinc-500 uppercase">{card.title}</span>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -22,10 +22,10 @@ export default function Modal() {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-in fade-in duration-200">
       <div className="retro-card p-8 max-w-md w-full mx-4 animate-in zoom-in-95 duration-200">
         <div className="mb-6">
-          <h3 className="text-xl font-black uppercase tracking-widest text-white mb-2">
+          <h3 className="text-xl font-black uppercase tracking-widest text-[var(--color-fin-text)] mb-2">
             {type === 'confirm' ? 'Confirm Action' : 'Alert'}
           </h3>
-          <p className="text-gray-300 leading-relaxed">
+          <p className="text-[var(--color-fin-muted)] leading-relaxed">
             {message}
           </p>
         </div>
@@ -34,7 +34,7 @@ export default function Modal() {
           {type === 'confirm' && (
             <button
               onClick={handleCancel}
-              className="px-6 py-3 border border-[#1F1F1F] text-gray-400 hover:text-white hover:border-gray-500 font-bold uppercase tracking-wider transition-colors"
+              className="px-6 py-3 border border-[var(--color-fin-border)] text-[var(--color-fin-muted)] hover:text-[var(--color-fin-text)] hover:border-[var(--color-fin-accent)] font-bold uppercase tracking-wider transition-colors"
             >
               {cancelText}
             </button>

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -12,20 +12,20 @@ export default function ProtectedRoute({ children }) {
   if (loading) {
     return (
       <div
+        className="theme-route-loader"
         style={{
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
           height: '100vh',
-          background: '#080808',
         }}
       >
         <div
           style={{
             width: 40,
             height: 40,
-            border: '3px solid #222',
-            borderTopColor: '#FF6B00',
+            border: '3px solid var(--color-fin-border)',
+            borderTopColor: 'var(--color-fin-accent)',
             borderRadius: '50%',
             animation: 'spin 0.8s linear infinite',
           }}

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,12 +1,14 @@
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
-import { LogOut, User, ChevronDown } from "lucide-react";
+import { useTheme } from "../../context/ThemeContext";
+import { LogOut, ChevronDown, MoonStar, SunMedium } from "lucide-react";
 import { useState, useRef, useEffect } from "react";
 
 export default function Header() {
   const location = useLocation();
   const navigate = useNavigate();
   const { user, signOut } = useAuth();
+  const { theme, toggleTheme } = useTheme();
 
   const [profileOpen, setProfileOpen] = useState(false);
   const dropdownRef = useRef(null);
@@ -61,16 +63,13 @@ export default function Header() {
 
   return (
     <header
-      className="h-16 flex items-center px-4 md:px-8 shrink-0 gap-4 w-full z-40"
+      className="theme-header h-16 flex items-center px-4 md:px-8 shrink-0 gap-4 w-full z-40"
       style={{
-        background: "rgba(10,10,10,0.8)",
         backdropFilter: "blur(12px)",
-        borderBottom: "1px solid #1a1a1a",
       }}
     >
       <label htmlFor="mobile-drawer"
-        className="p-2 cursor-pointer rounded-lg transition-colors lg:hidden"
-        style={{ color: "#FF6B00" }}
+        className="theme-icon-button p-2 cursor-pointer rounded-lg transition-colors lg:hidden"
       >
         <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
           <line x1="3" y1="12" x2="21" y2="12"></line>
@@ -80,14 +79,23 @@ export default function Header() {
       </label>
 
       <div className="flex flex-col">
-        <h1 className="text-base font-bold text-white tracking-wide leading-tight">
+        <h1 className="text-base font-bold text-[var(--color-fin-text)] tracking-wide leading-tight">
           {getPageTitle()}
         </h1>
-        <p className="text-xs text-gray-500 leading-tight">{getPageSubtitle()}</p>
+        <p className="text-xs text-[var(--color-fin-muted)] leading-tight">{getPageSubtitle()}</p>
       </div>
 
+      <button
+        type="button"
+        onClick={toggleTheme}
+        className="theme-toggle-button ml-auto inline-flex items-center rounded-full px-3 py-2 transition-all duration-200"
+        aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      >
+        {theme === 'dark' ? <SunMedium size={14} /> : <MoonStar size={14} />}
+      </button>
+
       {/* ── Profile section ──────────────────────────────────────── */}
-      <div className="ml-auto flex items-center gap-3 relative" ref={dropdownRef}>
+      <div className="flex items-center gap-3 relative" ref={dropdownRef}>
         <button
           onClick={() => setProfileOpen(!profileOpen)}
           className="profile-trigger"
@@ -105,7 +113,7 @@ export default function Header() {
             style={{
               transform: profileOpen ? "rotate(180deg)" : "rotate(0deg)",
               transition: "transform 0.2s ease",
-              color: "#666",
+              color: "var(--color-fin-muted)",
             }}
           />
         </button>

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -7,7 +7,7 @@ export default function Layout() {
   const { authError, clearAuthError } = useAuth();
 
   return (
-    <div className="drawer lg:drawer-open text-white h-screen overflow-hidden">
+    <div className="drawer lg:drawer-open theme-shell h-screen overflow-hidden">
       <input id="mobile-drawer" type="checkbox" className="drawer-toggle" />
       <div className="drawer-content flex flex-col flex-1 h-screen overflow-hidden">
         <Header />

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -15,18 +15,17 @@ export default function Sidebar() {
   ];
 
   return (
-    <div className="w-64 flex flex-col h-full shrink-0"
-      style={{ background: "linear-gradient(180deg, #0D0D0D 0%, #080808 100%)", borderRight: "1px solid #1a1a1a" }}>
+    <div className="theme-sidebar w-64 flex flex-col h-full shrink-0">
       
       {/* Logo */}
       <div className="flex flex-col items-center justify-center p-8 gap-3"
-        style={{ borderBottom: "1px solid #1a1a1a" }}>
+        style={{ borderBottom: "1px solid var(--color-fin-border)" }}>
         <div className="relative">
           <div className="absolute inset-0 rounded-2xl blur-xl opacity-40"
-            style={{ background: "rgba(255,107,0,0.4)" }} />
+            style={{ background: "var(--color-fin-accent-soft)" }} />
           <img
             className="relative w-20 h-20 object-cover rounded-2xl"
-            style={{ border: "1px solid rgba(255,107,0,0.3)", boxShadow: "0 0 24px rgba(255,107,0,0.25)" }}
+            style={{ border: "1px solid var(--color-fin-border-hover)", boxShadow: "0 0 24px var(--color-fin-shadow-accent)" }}
             src={finbGif}
             alt="finboard icon"
           />
@@ -34,9 +33,9 @@ export default function Sidebar() {
         <span
           className="text-2xl text-transparent bg-clip-text"
           style={{
-            backgroundImage: "linear-gradient(135deg, #FF6B00 0%, #FF8C00 50%, #FFA500 100%)",
+            backgroundImage: "linear-gradient(135deg, var(--color-fin-accent) 0%, var(--color-fin-accent-strong) 100%)",
             fontFamily: "'Righteous', 'Bungee', cursive",
-            filter: "drop-shadow(0 2px 8px rgba(255,107,0,0.4))"
+            filter: "drop-shadow(0 2px 8px var(--color-fin-shadow-accent))"
           }}
         >
           FINBOARD
@@ -60,13 +59,13 @@ export default function Sidebar() {
               }}
               className={`flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-semibold transition-all duration-200 ${
                 isActive
-                  ? "text-white"
-                  : "text-gray-500 hover:text-gray-200"
+                  ? "text-[var(--color-fin-text)]"
+                  : "text-[var(--color-fin-muted)] hover:text-[var(--color-fin-text)]"
               }`}
               style={isActive ? {
-                background: "linear-gradient(135deg, rgba(255,107,0,0.15) 0%, rgba(255,107,0,0.05) 100%)",
-                border: "1px solid rgba(255,107,0,0.25)",
-                boxShadow: "0 4px 16px rgba(255,107,0,0.08)"
+                background: "linear-gradient(135deg, var(--color-fin-accent-soft) 0%, transparent 100%)",
+                border: "1px solid color-mix(in srgb, var(--color-fin-accent) 25%, transparent)",
+                boxShadow: "0 4px 16px var(--color-fin-shadow-accent)"
               } : {
                 background: "transparent",
                 border: "1px solid transparent",
@@ -74,11 +73,11 @@ export default function Sidebar() {
             >
               <Icon
                 size={18}
-                className={isActive ? "text-[#FF6B00]" : "text-gray-600"}
+                className={isActive ? "text-[var(--color-fin-accent)]" : "text-[var(--color-fin-muted)]"}
               />
               {link.name}
               {isActive && (
-                <div className="ml-auto w-1.5 h-1.5 rounded-full bg-[#FF6B00]" />
+                <div className="ml-auto w-1.5 h-1.5 rounded-full bg-[var(--color-fin-accent)]" />
               )}
             </Link>
           );
@@ -86,13 +85,13 @@ export default function Sidebar() {
       </nav>
 
       {/* Footer */}
-      <div className="p-4 flex flex-col gap-2" style={{ borderTop: "1px solid #1a1a1a" }}>
+      <div className="p-4 flex flex-col gap-2" style={{ borderTop: "1px solid var(--color-fin-border)" }}>
         
           <a href="https://github.com/khanirfan18"
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-xl text-xs font-bold tracking-wider text-gray-500 hover:text-white transition-all duration-200"
-          style={{ border: "1px solid #1a1a1a" }}
+          className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-xl text-xs font-bold tracking-wider text-[var(--color-fin-muted)] hover:text-[var(--color-fin-text)] transition-all duration-200"
+          style={{ border: "1px solid var(--color-fin-border)" }}
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
@@ -103,8 +102,8 @@ export default function Sidebar() {
           <a href="https://irfandev.me"
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-xl text-xs font-bold tracking-wider text-gray-500 hover:text-white transition-all duration-200"
-          style={{ border: "1px solid #1a1a1a" }}
+          className="flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-xl text-xs font-bold tracking-wider text-[var(--color-fin-muted)] hover:text-[var(--color-fin-text)] transition-all duration-200"
+          style={{ border: "1px solid var(--color-fin-border)" }}
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect>

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -125,13 +125,8 @@ export function AppContext({ children }) {
       converting,
     }}>
       {converting && (
-        <div style={{
-          position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
-          background: 'rgba(0,0,0,0.7)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          zIndex: 9999,
-        }}>
-          <div style={{ color: '#FF6B00', fontSize: '1.2rem', fontWeight: 'bold' }}>
+        <div className="theme-overlay">
+          <div className="theme-overlay-card">
             Converting transactions... please wait
           </div>
         </div>

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,0 +1,67 @@
+/* eslint-disable react-refresh/only-export-components */
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext(null);
+const STORAGE_KEY = 'finboard-theme';
+
+export function getStoredTheme() {
+  if (typeof window === 'undefined') {
+    return 'dark';
+  }
+
+  try {
+    const storedTheme = window.localStorage.getItem(STORAGE_KEY);
+    if (storedTheme === 'light' || storedTheme === 'dark') {
+      return storedTheme;
+    }
+  } catch {
+    // Ignore storage failures and fall back to the default theme.
+  }
+
+  return 'dark';
+}
+
+export function applyThemeToDocument(theme) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+  document.body.dataset.theme = theme;
+  document.body.style.colorScheme = theme;
+}
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(getStoredTheme);
+
+  useEffect(() => {
+    applyThemeToDocument(theme);
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      // Ignore storage failures so the UI still works without persistence.
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((currentTheme) => (currentTheme === 'dark' ? 'light' : 'dark'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,10 @@
   font-family: "Inter", sans-serif;
   --color-fin-surface: #111111;
   --color-fin-surface-2: #161616;
+  --color-fin-surface-soft: rgba(255, 255, 255, 0.03);
   --color-fin-border-strong: #2a2a2a;
+  --color-fin-border-soft: rgba(255, 255, 255, 0.08);
+  --color-fin-border-hover-soft: rgba(255, 255, 255, 0.14);
   --color-fin-border-hover: var(--color-fin-accent);
   --color-fin-accent: #FF6B00;
   --color-fin-accent-strong: #FF8C00;
@@ -37,8 +40,11 @@ body[data-theme="light"] {
   --color-fin-bg: #ffffff;
   --color-fin-surface: #f7f3ff;
   --color-fin-surface-2: #f0e8ff;
+  --color-fin-surface-soft: rgba(139, 92, 246, 0.03);
   --color-fin-border: #e4daf7;
   --color-fin-border-strong: #d2c2ef;
+  --color-fin-border-soft: rgba(36, 27, 55, 0.08);
+  --color-fin-border-hover-soft: rgba(139, 92, 246, 0.18);
   --color-fin-text: #241b37;
   --color-fin-muted: #6c6484;
   --color-fin-accent: #8b5cf6;
@@ -262,25 +268,24 @@ body[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
 }
 
 .fin-card {
-  border: 1px solid var(--color-fin-border);
+  border: 1px solid var(--color-fin-border-soft);
   border-radius: 16px;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
 }
 .fin-card:hover {
-  border-color: rgba(255, 107, 0, 0.4);
-  box-shadow: 0 8px 32px rgba(255, 107, 0, 0.1), 0 4px 24px rgba(0, 0, 0, 0.5);
-  transform: translateY(-2px);
+  border-color: var(--color-fin-border-hover-soft);
+  box-shadow: 0 2px 14px rgba(0, 0, 0, 0.2);
 }
 
 /* ── Metric Cards ──────────────────────────────────────────────────────────── */
 .fin-metric-card {
   background: linear-gradient(135deg, #161616 0%, #121212 100%);
-  border: 1px solid var(--color-fin-border);
+  border: 1px solid var(--color-fin-border-soft);
   border-radius: 20px;
   padding: 1.5rem;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
   position: relative;
   overflow: hidden;
 }
@@ -291,48 +296,46 @@ body[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
   left: 0;
   right: 0;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(255, 107, 0, 0.5), transparent);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.14), transparent);
 }
 .fin-metric-card:hover {
-  border-color: rgba(255, 107, 0, 0.35);
-  box-shadow: 0 12px 40px rgba(255, 107, 0, 0.08), 0 4px 24px rgba(0, 0, 0, 0.5);
-  transform: translateY(-3px);
+  border-color: var(--color-fin-border-hover-soft);
+  box-shadow: 0 2px 14px rgba(0, 0, 0, 0.2);
 }
 
 /* ── Retro Card (legacy support) ───────────────────────────────────────────── */
 .retro-card {
   background: linear-gradient(135deg, #161616 0%, #111111 100%);
-  border: 1px solid var(--color-fin-border);
+  border: 1px solid var(--color-fin-border-soft);
   border-radius: 16px;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
 }
 .retro-card:hover {
-  border-color: rgba(255, 107, 0, 0.4);
-  box-shadow: 0 8px 32px rgba(255, 107, 0, 0.1);
+  border-color: var(--color-fin-border-hover-soft);
+  box-shadow: 0 2px 14px rgba(0, 0, 0, 0.2);
 }
 
 /* ── Buttons ───────────────────────────────────────────────────────────────── */
 .retro-btn {
   background: linear-gradient(135deg, #FF6B00 0%, #FF8C00 100%);
-  color: #000000;
-  border: none;
+  color: whitesmoke;
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 10px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   padding: 0.75rem 1.5rem;
-  box-shadow: 0 4px 16px rgba(255, 107, 0, 0.3);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
 }
 .retro-btn:hover {
   background: linear-gradient(135deg, #FF8C00 0%, #FFA500 100%);
-  box-shadow: 0 6px 24px rgba(255, 107, 0, 0.45);
-  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
 }
 .retro-btn:active {
-  transform: translateY(0);
-  box-shadow: 0 2px 8px rgba(255, 107, 0, 0.3);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.16);
 }
 
 /* ── Inputs ────────────────────────────────────────────────────────────────── */
@@ -618,25 +621,24 @@ body[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
   padding: 0.85rem 1.5rem;
   margin-top: 0.5rem;
   background: linear-gradient(135deg, #FF6B00 0%, #FF8C00 100%);
-  color: #000;
+  color: whitesmoke;
   font-size: 0.9rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  border: none;
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 12px;
   cursor: pointer;
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 4px 20px rgba(255, 107, 0, 0.3);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
 }
 .auth-submit-btn:hover:not(:disabled) {
   background: linear-gradient(135deg, #FF8C00 0%, #FFA500 100%);
-  box-shadow: 0 6px 28px rgba(255, 107, 0, 0.45);
-  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
 }
 .auth-submit-btn:active:not(:disabled) {
-  transform: translateY(0);
-  box-shadow: 0 2px 10px rgba(255, 107, 0, 0.3);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.16);
 }
 .auth-submit-btn:disabled {
   opacity: 0.7;

--- a/src/index.css
+++ b/src/index.css
@@ -17,25 +17,251 @@
 
 :root {
   font-family: "Inter", sans-serif;
+  --color-fin-surface: #111111;
+  --color-fin-surface-2: #161616;
+  --color-fin-border-strong: #2a2a2a;
+  --color-fin-border-hover: var(--color-fin-accent);
+  --color-fin-accent: #FF6B00;
+  --color-fin-accent-strong: #FF8C00;
+  --color-fin-accent-soft: rgba(255, 107, 0, 0.14);
+  --color-fin-accent-rgb: 255, 107, 0;
+  --color-fin-shadow: rgba(0, 0, 0, 0.4);
+  --color-fin-shadow-accent: rgba(255, 107, 0, 0.25);
+  --color-fin-bg-elevated: #0c0c0c;
+  --color-fin-text-inverse: #000000;
   background-color: var(--color-fin-bg);
-  color: var(--color-fin-text);
+}
+
+:root[data-theme="light"],
+body[data-theme="light"] {
+  --color-fin-bg: #ffffff;
+  --color-fin-surface: #f7f3ff;
+  --color-fin-surface-2: #f0e8ff;
+  --color-fin-border: #e4daf7;
+  --color-fin-border-strong: #d2c2ef;
+  --color-fin-text: #241b37;
+  --color-fin-muted: #6c6484;
+  --color-fin-accent: #8b5cf6;
+  --color-fin-accent-strong: #a78bfa;
+  --color-fin-border-hover: var(--color-fin-accent);
+  --color-fin-accent-soft: rgba(139, 92, 246, 0.12);
+  --color-fin-accent-rgb: 139, 92, 246;
+  --color-fin-shadow: rgba(139, 92, 246, 0.12);
+  --color-fin-shadow-accent: rgba(139, 92, 246, 0.2);
+  --color-fin-bg-elevated: #fbf8ff;
+  --color-fin-text-inverse: #ffffff;
 }
 
 body {
   background-color: var(--color-fin-bg);
+  color: var(--color-fin-text);
   background-image:
     radial-gradient(ellipse at 20% 20%, rgba(255, 107, 0, 0.04) 0%, transparent 50%),
     radial-gradient(ellipse at 80% 80%, rgba(255, 107, 0, 0.03) 0%, transparent 50%),
     linear-gradient(rgba(255, 255, 255, 0.015) 1px, transparent 1px),
     linear-gradient(90deg, rgba(255, 255, 255, 0.015) 1px, transparent 1px);
-  background-size: 100% 100%, 100% 100%, 40px 40px, 40px 40px;
-  color: var(--color-fin-text);
   min-height: 100vh;
 }
 
 /* ── Premium Cards ─────────────────────────────────────────────────────────── */
 .fin-card {
   background: linear-gradient(135deg, #161616 0%, #111111 100%);
+}
+
+body[data-theme="light"] {
+  background-image:
+    radial-gradient(ellipse at 20% 20%, rgba(var(--color-fin-accent-rgb), 0.12) 0%, transparent 52%),
+    radial-gradient(ellipse at 80% 80%, rgba(var(--color-fin-accent-rgb), 0.08) 0%, transparent 52%),
+    linear-gradient(rgba(139, 92, 246, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(139, 92, 246, 0.06) 1px, transparent 1px);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+*:focus-visible {
+  outline: 2px solid var(--color-fin-accent);
+  outline-offset: 2px;
+}
+
+body[data-theme="light"] .text-white,
+body[data-theme="light"] .text-gray-100,
+body[data-theme="light"] .text-gray-200 {
+  color: var(--color-fin-text) !important;
+}
+
+body[data-theme="light"] .text-gray-300,
+body[data-theme="light"] .text-gray-400,
+body[data-theme="light"] .text-gray-500,
+body[data-theme="light"] .text-gray-600,
+body[data-theme="light"] .text-zinc-300,
+body[data-theme="light"] .text-zinc-400,
+body[data-theme="light"] .text-zinc-500,
+body[data-theme="light"] .text-zinc-600 {
+  color: var(--color-fin-muted) !important;
+}
+
+body[data-theme="light"] [class*="bg-[#111111]"],
+body[data-theme="light"] [class*="bg-[#121214]"],
+body[data-theme="light"] [class*="bg-[#0a0a0a]"],
+body[data-theme="light"] [class*="bg-[#0D0D0D]"],
+body[data-theme="light"] [class*="bg-[#080808]"],
+body[data-theme="light"] [class*="bg-[#1F1F1F]"],
+body[data-theme="light"] [class*="bg-[#141414]"],
+body[data-theme="light"] [class*="bg-[#0c0c0c]"],
+body[data-theme="light"] [class*="bg-[#0A0A0A]"],
+body[data-theme="light"] [class*="bg-[#1a1a1a]"],
+body[data-theme="light"] [class*="bg-[#1e1e1e]"],
+body[data-theme="light"] [class*="bg-[#222222]"],
+body[data-theme="light"] [class*="bg-[#121212]"],
+body[data-theme="light"] [class*="bg-[#111]"] {
+  background-color: var(--color-fin-surface) !important;
+}
+
+body[data-theme="light"] [class*="border-[#1F1F1F]"],
+body[data-theme="light"] [class*="border-[#222]"],
+body[data-theme="light"] [class*="border-[#2a2a2a]"],
+body[data-theme="light"] [class*="border-[#1a1a1a]"],
+body[data-theme="light"] [class*="border-[#1e1e1e]"],
+body[data-theme="light"] [class*="border-zinc-800"],
+body[data-theme="light"] [class*="border-zinc-900"] {
+  border-color: var(--color-fin-border) !important;
+}
+
+body[data-theme="light"] [class*="text-[#FF6B00]"],
+body[data-theme="light"] [class*="text-[#FF8C00]"],
+body[data-theme="light"] [class*="text-[#FFA500]"] {
+  color: var(--color-fin-accent) !important;
+}
+
+body[data-theme="light"] [class*="bg-[#FF6B00]"],
+body[data-theme="light"] [class*="bg-[#FF8C00]"],
+body[data-theme="light"] [class*="bg-[#FFA500]"] {
+  background-color: var(--color-fin-accent) !important;
+}
+
+body[data-theme="light"] [class*="border-[#FF6B00]"],
+body[data-theme="light"] [class*="border-[#FF8C00]"],
+body[data-theme="light"] [class*="border-[#FFA500]"] {
+  border-color: var(--color-fin-accent) !important;
+}
+
+body[data-theme="light"] [class*="hover:text-[#FF6B00]"]:hover,
+body[data-theme="light"] [class*="hover:text-[#FF8C00]"]:hover,
+body[data-theme="light"] [class*="hover:text-[#FFA500]"]:hover {
+  color: var(--color-fin-accent) !important;
+}
+
+body[data-theme="light"] [class*="hover:border-[#FF6B00]"]:hover,
+body[data-theme="light"] [class*="hover:border-[#FF8C00]"]:hover,
+body[data-theme="light"] [class*="hover:border-[#FFA500]"]:hover {
+  border-color: var(--color-fin-accent) !important;
+}
+
+body[data-theme="light"] [class*="bg-[#FF6B00]/"],
+body[data-theme="light"] [class*="bg-[#FF8C00]/"],
+body[data-theme="light"] [class*="bg-[#FFA500]/"] {
+  background-color: rgba(var(--color-fin-accent-rgb), 0.12) !important;
+}
+
+body[data-theme="light"] .theme-panel,
+body[data-theme="light"] .theme-sidebar,
+body[data-theme="light"] .theme-header,
+body[data-theme="light"] .fin-card,
+body[data-theme="light"] .retro-card,
+body[data-theme="light"] .fin-metric-card,
+body[data-theme="light"] .auth-card,
+body[data-theme="light"] .profile-dropdown,
+body[data-theme="light"] .auth-input-wrap,
+body[data-theme="light"] .auth-social-btn {
+  background: var(--color-fin-surface) !important;
+  border-color: var(--color-fin-border) !important;
+  color: var(--color-fin-text) !important;
+}
+
+body[data-theme="light"] .theme-panel-strong,
+body[data-theme="light"] .theme-sidebar,
+body[data-theme="light"] .theme-header,
+body[data-theme="light"] .profile-dropdown,
+body[data-theme="light"] .auth-card {
+  background-color: var(--color-fin-bg) !important;
+}
+
+body[data-theme="light"] .theme-border,
+body[data-theme="light"] .retro-input,
+body[data-theme="light"] .auth-input-wrap,
+body[data-theme="light"] .profile-trigger,
+body[data-theme="light"] .profile-dropdown-item,
+body[data-theme="light"] .auth-social-btn,
+body[data-theme="light"] .table :where(th, td) {
+  border-color: var(--color-fin-border) !important;
+}
+
+body[data-theme="light"] .theme-accent,
+body[data-theme="light"] .fin-badge,
+body[data-theme="light"] .auth-link,
+body[data-theme="light"] .auth-link-btn,
+body[data-theme="light"] .profile-avatar,
+body[data-theme="light"] .auth-logo,
+body[data-theme="light"] .fin-section-title {
+  color: var(--color-fin-accent) !important;
+}
+
+body[data-theme="light"] .theme-accent-bg,
+body[data-theme="light"] .retro-btn,
+body[data-theme="light"] .auth-submit-btn,
+body[data-theme="light"] .theme-toggle,
+body[data-theme="light"] .theme-toggle-button {
+  background: var(--color-fin-accent) !important;
+  color: var(--color-fin-text-inverse) !important;
+}
+
+body[data-theme="light"] .theme-toggle:hover,
+body[data-theme="light"] .theme-toggle-button:hover,
+body[data-theme="light"] .retro-btn:hover,
+body[data-theme="light"] .auth-submit-btn:hover {
+  background: var(--color-fin-accent-strong) !important;
+}
+
+body[data-theme="light"] .theme-toggle svg,
+body[data-theme="light"] .theme-toggle-button svg {
+  color: inherit !important;
+}
+
+body[data-theme="light"] .theme-route-loader {
+  background: var(--color-fin-bg) !important;
+}
+
+body[data-theme="light"] .theme-route-loader div {
+  border-color: var(--color-fin-border) !important;
+  border-top-color: var(--color-fin-accent) !important;
+}
+
+body[data-theme="light"] .theme-overlay {
+  background: rgba(255, 255, 255, 0.72) !important;
+}
+
+body[data-theme="light"] .theme-overlay-card {
+  color: var(--color-fin-accent) !important;
+}
+
+body[data-theme="light"] ::-webkit-scrollbar-track {
+  background: #efe9fb;
+}
+
+body[data-theme="light"] ::-webkit-scrollbar-thumb {
+  background: #c7b5f3;
+}
+
+body[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
+  background: var(--color-fin-accent);
+}
+
+.fin-card {
   border: 1px solid var(--color-fin-border);
   border-radius: 16px;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -674,4 +900,88 @@ body {
 .profile-dropdown-item--danger:hover {
   background: rgba(239, 68, 68, 0.1);
   color: #f87171;
+}
+
+.theme-shell {
+  background: var(--color-fin-bg);
+  color: var(--color-fin-text);
+}
+
+.theme-panel {
+  background: var(--color-fin-surface);
+  border: 1px solid var(--color-fin-border);
+  color: var(--color-fin-text);
+}
+
+.theme-panel-strong {
+  background: var(--color-fin-surface-2);
+}
+
+.theme-border {
+  border-color: var(--color-fin-border);
+}
+
+.theme-accent {
+  color: var(--color-fin-accent);
+}
+
+.theme-accent-bg {
+  background: var(--color-fin-accent);
+  color: var(--color-fin-text-inverse);
+}
+
+.theme-header {
+  background: rgba(10, 10, 10, 0.8);
+  border-bottom: 1px solid var(--color-fin-border);
+}
+
+.theme-sidebar {
+  background: linear-gradient(180deg, var(--color-fin-surface) 0%, var(--color-fin-bg) 100%);
+  border-right: 1px solid var(--color-fin-border);
+}
+
+.theme-icon-button {
+  color: var(--color-fin-accent);
+}
+
+.theme-toggle-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-fin-border);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--color-fin-text);
+}
+
+.theme-toggle-button:hover {
+  border-color: var(--color-fin-accent);
+  color: var(--color-fin-accent);
+}
+
+.theme-route-loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: var(--color-fin-bg);
+}
+
+.theme-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.theme-overlay-card {
+  color: var(--color-fin-accent);
+  font-size: 1.2rem;
+  font-weight: 700;
 }

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,11 +1,24 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL?.trim();
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim();
 
 if (!supabaseUrl || !supabaseAnonKey) {
+  const missing = [
+    !supabaseUrl ? "VITE_SUPABASE_URL" : null,
+    !supabaseAnonKey ? "VITE_SUPABASE_ANON_KEY" : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
   throw new Error(
-    "Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables"
+    `Missing ${missing} environment variable(s). Create a .env file in the project root with:\nVITE_SUPABASE_URL=https://your-project-ref.supabase.co\nVITE_SUPABASE_ANON_KEY=your-anon-key\nThen restart the Vite dev server.`
+  );
+}
+
+if (!/^https?:\/\//i.test(supabaseUrl)) {
+  throw new Error(
+    "Invalid VITE_SUPABASE_URL. Use the full URL, for example: https://your-project-ref.supabase.co"
   );
 }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,17 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import "@fontsource/inter";
+import { applyThemeToDocument, getStoredTheme } from './context/ThemeContext';
+
+let bootTheme = 'dark';
+
+try {
+  bootTheme = getStoredTheme();
+} catch {
+  bootTheme = 'dark';
+}
+
+applyThemeToDocument(bootTheme);
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/pages/Budgets.jsx
+++ b/src/pages/Budgets.jsx
@@ -94,9 +94,9 @@ export default function Budgets() {
   };
 
   const panelCardClass =
-    "retro-card p-6 h-full flex flex-col animate-in fade-in duration-500 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_24px_rgba(255,107,0,0.12)]";
+    "retro-card p-6 h-full flex flex-col animate-in fade-in duration-500 transition-all duration-300 hover:border-[#FF6B00]/20";
   const budgetCardClass =
-    "retro-card p-6 h-full min-h-[320px] flex flex-col animate-in fade-in duration-500 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_24px_rgba(255,107,0,0.12)]";
+    "retro-card p-6 h-full min-h-[320px] flex flex-col animate-in fade-in duration-500 transition-all duration-300 hover:border-[#FF6B00]/20";
 
   return transactions && categories.length > 0 ? (
     <div className="space-y-6 animate-in fade-in duration-500">
@@ -309,7 +309,7 @@ export default function Budgets() {
     </div>
   ) : (
     <div className="flex flex-col items-center justify-center h-full min-h-[60vh]">
-      <div className="retro-card p-12 flex flex-col items-center max-w-md text-center border-[#FF6B00]/30 shadow-[0_0_20px_rgba(255,107,0,0.1)] animate-in fade-in zoom-in-95 duration-500 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_24px_rgba(255,107,0,0.12)]">
+      <div className="retro-card p-12 flex flex-col items-center max-w-md text-center border-[#FF6B6B]/20 animate-in fade-in zoom-in-95 duration-500 transition-all duration-300 hover:border-[#FF6B6B]/28">
         <div className="w-16 h-16 bg-[#FF6B00]/10 flex items-center justify-center rounded-full mb-6 text-[#FF6B00]">
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/Budgets.jsx
+++ b/src/pages/Budgets.jsx
@@ -4,9 +4,11 @@ import { Link } from "react-router-dom";
 import categorize from "../components/utils/categorize";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import { useModal } from "../context/ModalContext";
+import { useTheme } from "../context/ThemeContext";
 
 export default function Budgets() {
   const { showModal } = useModal();
+  const { theme } = useTheme();
   const [budgets, setBudgets] = React.useState(() => {
     const saved = localStorage.getItem("budgets");
     return saved ? JSON.parse(saved) : {};
@@ -81,6 +83,11 @@ export default function Budgets() {
 
   const getProgressColor = (spent, budget) => {
     const percentage = (spent / budget) * 100;
+    if (theme === "light") {
+      if (percentage >= 100) return "#A78BFA";
+      if (percentage >= 80) return "#C4B5FD";
+      return "#8B5CF6";
+    }
     if (percentage >= 100) return "#FF6B6B";
     if (percentage >= 80) return "#FFBB28";
     return "#FF6B00";
@@ -199,8 +206,8 @@ export default function Budgets() {
                 }}
               />
               <Legend wrapperStyle={{ paddingTop: "20px" }} />
-              <Bar dataKey="spent" fill="#FF6B6B" name="Spent" radius={[2, 2, 0, 0]} />
-              <Bar dataKey="budget" fill="#00C49F" name="Budget" radius={[2, 2, 0, 0]} />
+              <Bar dataKey="spent" fill={theme === "light" ? "#8B5CF6" : "#FF6B6B"} name="Spent" radius={[2, 2, 0, 0]} />
+              <Bar dataKey="budget" fill={theme === "light" ? "#A78BFA" : "#00C49F"} name="Budget" radius={[2, 2, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         </div>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -268,7 +268,7 @@ return (
           </>
         ) : (
           <div className="flex flex-col items-center justify-center h-full min-h-[78vh] pt-10 animate-in fade-in duration-500">
-            <div className="retro-card p-12 flex flex-col items-center max-w-md text-center border-[#FF6B00]/30 shadow-[0_0_20px_rgba(255,107,0,0.1)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_24px_rgba(255,107,0,0.12)]">
+            <div className="retro-card p-12 flex flex-col items-center max-w-md text-center border-[#FF6B00]/20 transition-all duration-300 hover:border-[#FF6B00]/28">
               <div className="w-16 h-16 bg-[#FF6B00]/10 flex items-center justify-center rounded-full mb-6 text-[#FF6B00]">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -16,9 +16,11 @@ import {
 import React from "react";
 import { parse, format } from "date-fns";
 import { TrendingUp, TrendingDown, PiggyBank, Plus, X } from "lucide-react";
+import { useTheme } from "../context/ThemeContext";
 
 export default function Dashboard() {
   const { transactions, currency, addTransaction } = React.useContext(DataContext);
+  const { theme } = useTheme();
 
   const [loading] = React.useState(false);
   const [showForm, setShowForm] = React.useState(false);
@@ -73,15 +75,12 @@ export default function Dashboard() {
     setTimeout(() => setSuccessMsg(""), 3000);
   };
 
-  const COLORS = [
-    "#0088FE",
-    "#00C49F",
-    "#FFBB28",
-    "#FF8042",
-    "#A28DFF",
-    "#FF6B6B",
-    "#82ca9d",
-  ];
+  const COLORS = theme === "light"
+    ? ["#8B5CF6", "#A78BFA", "#C4B5FD", "#DDD6FE", "#EDE9FE", "#F5F3FF", "#7C3AED"]
+    : ["#0088FE", "#00C49F", "#FFBB28", "#FF8042", "#A28DFF", "#FF6B6B", "#82ca9d"];
+
+  const metricAccent = theme === "light" ? "rgba(139,92,246,0.12)" : undefined;
+  const metricBorder = theme === "light" ? "1px solid rgba(139,92,246,0.22)" : undefined;
 
   const totalIncome = transactions?.reduce((acc, amt) => {
     const num = Number(amt.Amount);
@@ -167,8 +166,8 @@ return (
                   <div
                     className="p-3 rounded-xl"
                     style={{
-                      background: "rgba(0,196,159,0.1)",
-                      border: "1px solid rgba(0,196,159,0.2)",
+                      background: metricAccent || "rgba(0,196,159,0.1)",
+                      border: metricBorder || "1px solid rgba(0,196,159,0.2)",
                     }}
                   >
                     <TrendingUp className="w-5 h-5 text-[#00C49F]" />
@@ -191,8 +190,8 @@ return (
                   <div
                     className="p-3 rounded-xl"
                     style={{
-                      background: "rgba(255,107,107,0.1)",
-                      border: "1px solid rgba(255,107,107,0.2)",
+                      background: metricAccent || "rgba(255,107,107,0.1)",
+                      border: metricBorder || "1px solid rgba(255,107,107,0.2)",
                     }}
                   >
                     <TrendingDown className="w-5 h-5 text-[#FF6B6B]" />
@@ -215,8 +214,8 @@ return (
                   <div
                     className="p-3 rounded-xl"
                     style={{
-                      background: "rgba(0,136,254,0.1)",
-                      border: "1px solid rgba(0,136,254,0.2)",
+                      background: metricAccent || "rgba(0,136,254,0.1)",
+                      border: metricBorder || "1px solid rgba(0,136,254,0.2)",
                     }}
                   >
                     <PiggyBank className="w-5 h-5 text-[#0088FE]" />
@@ -260,8 +259,8 @@ return (
                     <YAxis />
                     <Tooltip />
                     <Legend />
-                    <Bar dataKey="income" fill="#00C49F" />
-                    <Bar dataKey="spent" fill="#FF6B6B" />
+                    <Bar dataKey="income" fill={theme === "light" ? "#8B5CF6" : "#00C49F"} />
+                    <Bar dataKey="spent" fill={theme === "light" ? "#A78BFA" : "#FF6B6B"} />
                   </BarChart>
                 </ResponsiveContainer>
               </div>

--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -9,8 +9,10 @@ import DialogTitle from '@mui/material/DialogTitle';
 import OutlinedInput from '@mui/material/OutlinedInput';
 import Alert from '@mui/material/Alert';
 import { supabase } from '../lib/supabaseClient';
+import { useTheme } from '../context/ThemeContext';
 
 function ForgotPassword({ open, handleClose }) {
+  const { theme } = useTheme();
   const [email, setEmail] = React.useState('');
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState('');
@@ -64,30 +66,30 @@ function ForgotPassword({ open, handleClose }) {
           onSubmit: handleSubmit,
           sx: { 
             backgroundImage: 'none',
-            backgroundColor: '#0a0a0a',
-            border: '1px solid #1f1f1f',
-            color: '#fff',
+            backgroundColor: theme === 'light' ? 'var(--color-fin-surface)' : 'var(--color-fin-bg-elevated)',
+            border: '1px solid var(--color-fin-border)',
+            color: 'var(--color-fin-text)',
           },
         },
       }}
     >
-      <DialogTitle sx={{ color: '#fff', fontWeight: 'bold' }}>Reset password</DialogTitle>
+      <DialogTitle sx={{ color: 'var(--color-fin-text)', fontWeight: 'bold' }}>Reset password</DialogTitle>
       <DialogContent
         sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: '100%', minWidth: { xs: 280, sm: 400 } }}
       >
-        <DialogContentText sx={{ color: '#aaa' }}>
+        <DialogContentText sx={{ color: 'var(--color-fin-muted)' }}>
           Enter your account&apos;s email address, and we&apos;ll send you a link to
           reset your password.
         </DialogContentText>
         
         {error && (
-          <Alert severity="error" sx={{ backgroundColor: '#1a0d0d', color: '#ff8888', border: '1px solid #3d1a1a', '& .MuiAlert-icon': { color: '#ff8888' } }}>
+          <Alert severity="error" sx={{ backgroundColor: 'rgba(239, 68, 68, 0.08)', color: 'var(--color-fin-text)', border: '1px solid rgba(239, 68, 68, 0.2)', '& .MuiAlert-icon': { color: '#ef4444' } }}>
             {error}
           </Alert>
         )}
         
         {success && (
-          <Alert severity="success" sx={{ backgroundColor: '#0d1a0d', color: '#88ff88', border: '1px solid #1a3d1a', '& .MuiAlert-icon': { color: '#88ff88' } }}>
+          <Alert severity="success" sx={{ backgroundColor: 'rgba(139, 92, 246, 0.08)', color: 'var(--color-fin-text)', border: '1px solid rgba(139, 92, 246, 0.2)', '& .MuiAlert-icon': { color: 'var(--color-fin-accent)' } }}>
             {success}
           </Alert>
         )}
@@ -106,21 +108,21 @@ function ForgotPassword({ open, handleClose }) {
           onChange={(e) => setEmail(e.target.value)}
           disabled={loading || !!success}
           sx={{
-            color: '#fff',
+            color: 'var(--color-fin-text)',
             '& .MuiOutlinedInput-notchedOutline': {
-              borderColor: '#222',
+              borderColor: 'var(--color-fin-border)',
             },
             '&:hover .MuiOutlinedInput-notchedOutline': {
-              borderColor: '#444',
+              borderColor: 'var(--color-fin-muted)',
             },
             '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-              borderColor: '#FF6B00',
+              borderColor: 'var(--color-fin-accent)',
             },
           }}
         />
       </DialogContent>
       <DialogActions sx={{ pb: 3, px: 3 }}>
-        <Button onClick={handleCancel} disabled={loading} sx={{ color: '#aaa', '&:hover': { color: '#fff' } }}>
+        <Button onClick={handleCancel} disabled={loading} sx={{ color: 'var(--color-fin-muted)', '&:hover': { color: 'var(--color-fin-text)' } }}>
           Cancel
         </Button>
         <Button 
@@ -128,15 +130,15 @@ function ForgotPassword({ open, handleClose }) {
           type="submit" 
           disabled={loading || !!success}
           sx={{ 
-            backgroundColor: '#FF6B00', 
-            color: '#000', 
+            backgroundColor: 'var(--color-fin-accent)', 
+            color: 'var(--color-fin-text-inverse)', 
             fontWeight: 'bold',
             '&:hover': { 
-              backgroundColor: '#e05e00' 
+              backgroundColor: 'var(--color-fin-accent-strong)' 
             },
             '&.Mui-disabled': {
-              backgroundColor: '#333',
-              color: '#666',
+              backgroundColor: 'var(--color-fin-border)',
+              color: 'var(--color-fin-muted)',
             }
           }}
         >

--- a/src/pages/InsightsDashboard.jsx
+++ b/src/pages/InsightsDashboard.jsx
@@ -10,7 +10,7 @@ export default function InsightsDashboard() {
   if (!transactions || transactions.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full min-h-[60vh] animate-in fade-in duration-500">
-        <div className="retro-card p-12 flex flex-col items-center max-w-md text-center border-[#FF6B00]/30 shadow-[0_0_20px_rgba(255,107,0,0.1)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_24px_rgba(255,107,0,0.12)]">
+        <div className="retro-card p-12 flex flex-col items-center max-w-md text-center border-[#FF6B00]/20 transition-all duration-300 hover:border-[#FF6B00]/28">
           <div className="w-16 h-16 bg-[#FF6B00]/10 flex items-center justify-center rounded-full mb-6 text-[#FF6B00]">
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -79,15 +79,15 @@ export default function ResetPassword() {
           alignItems: 'center',
           justifyContent: 'center',
           height: '100vh',
-          background: '#080808',
+          background: 'var(--color-fin-bg)',
         }}
       >
         <div
           style={{
             width: 40,
             height: 40,
-            border: '3px solid #222',
-            borderTopColor: '#FF6B00',
+            border: '3px solid var(--color-fin-border)',
+            borderTopColor: 'var(--color-fin-accent)',
             borderRadius: '50%',
             animation: 'spin 0.8s linear infinite',
           }}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -9,7 +9,7 @@ import { useModal } from "../context/ModalContext";
 // REUSABLE SECTION COMPONENT
 // =========================
 const Section = ({ title, subtitle, children, right }) => (
-  <div className="w-full rounded-[24px] border border-[#222] bg-[#141414] p-6 md:p-8 transition-all duration-300 hover:border-[#FF6B00]/30 hover:shadow-[0_0_20px_rgba(255,107,0,0.05)]">
+  <div className="w-full rounded-[24px] border border-[#2a2a2a] bg-[#141414] p-6 md:p-8 transition-all duration-300 hover:border-[#FF6B00]/20">
 
     <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
 

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -10,7 +10,7 @@ import { useModal } from "../context/ModalContext";
 // REUSABLE SECTION COMPONENT
 // =========================
 const Section = ({ title, subtitle, children, right }) => (
-  <div className="w-full rounded-[24px] border border-[#222] bg-[#141414] p-6 md:p-8 transition-all duration-300 hover:border-[#FF6B00]/30 hover:shadow-[0_0_20px_rgba(255,107,0,0.05)]">
+  <div className="w-full rounded-[24px] border border-[#2a2a2a] bg-[#141414] p-6 md:p-8 transition-all duration-300 hover:border-[#FF6B00]/20">
 
     <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
 
@@ -224,7 +224,7 @@ export default function Settings() {
                 onClick={() => setImportMode(mode)}
                 className={`h-[42px] px-5 text-xs font-bold uppercase transition-all ${
                   importMode === mode
-                    ? "bg-[#FF6B00] text-black"
+                    ? "bg-[#FF6B00] text-[whitesmoke]"
                     : "bg-[#111] text-gray-400 hover:text-white"
                 }`}
               >
@@ -247,6 +247,14 @@ export default function Settings() {
                 const mapped = demoData.map((d) => ({ ...d, source: 'demo' }));
                 const normalized = normalizeTransactions(mapped, { currency, source: 'demo' });
 
+<<<<<<< HEAD
+              setTransactions(updated);
+              localStorage.setItem("transactions", JSON.stringify(updated));
+              setSuccessMessage("Demo Data Loaded!");
+              setTimeout(() => setSuccessMessage(""), 3000);
+            }}
+            className="h-[48px] min-w-[240px] rounded-xl bg-[#FF6B00] px-8 text-sm font-black uppercase text-[whitesmoke]"
+=======
                 const updated = importMode === "append" ? [...(transactions || []), ...normalized] : normalized;
 
                 setTransactions(updated);
@@ -255,6 +263,7 @@ export default function Settings() {
                 setTimeout(() => setSuccessMessage(""), 3000);
               }}
             className="h-[48px] min-w-[240px] rounded-xl bg-[#FF6B00] px-8 text-sm font-black uppercase text-black"
+>>>>>>> cab0091e8739585ee6eb2c3310e0baf6455e1d6c
           >
             Load Demo Data
           </button>
@@ -268,7 +277,7 @@ export default function Settings() {
         right={
           <button
             onClick={() => setShowManualEntry(!showManualEntry)}
-            className="rounded-xl border border-[#222] px-5 py-2 text-sm font-semibold uppercase text-gray-400"
+            className="rounded-xl border border-[#222] px-5 py-2 text-sm font-semibold uppercase text-[whitesmoke]"
           >
             {showManualEntry ? "Hide Form" : "Show Form"}
           </button>
@@ -405,7 +414,7 @@ export default function Settings() {
             <div className="flex gap-3">
               <button
                 type="submit"
-                className="rounded-xl bg-[#FF6B00] px-7 py-3 font-black uppercase text-black"
+                className="rounded-xl bg-[#FF6B00] px-7 py-3 font-black uppercase text-[whitesmoke]"
               >
                 Add Transaction
               </button>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -247,14 +247,6 @@ export default function Settings() {
                 const mapped = demoData.map((d) => ({ ...d, source: 'demo' }));
                 const normalized = normalizeTransactions(mapped, { currency, source: 'demo' });
 
-<<<<<<< HEAD
-              setTransactions(updated);
-              localStorage.setItem("transactions", JSON.stringify(updated));
-              setSuccessMessage("Demo Data Loaded!");
-              setTimeout(() => setSuccessMessage(""), 3000);
-            }}
-            className="h-[48px] min-w-[240px] rounded-xl bg-[#FF6B00] px-8 text-sm font-black uppercase text-[whitesmoke]"
-=======
                 const updated = importMode === "append" ? [...(transactions || []), ...normalized] : normalized;
 
                 setTransactions(updated);
@@ -263,7 +255,6 @@ export default function Settings() {
                 setTimeout(() => setSuccessMessage(""), 3000);
               }}
             className="h-[48px] min-w-[240px] rounded-xl bg-[#FF6B00] px-8 text-sm font-black uppercase text-black"
->>>>>>> cab0091e8739585ee6eb2c3310e0baf6455e1d6c
           >
             Load Demo Data
           </button>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -219,7 +219,7 @@ export default function Settings() {
                 onClick={() => setImportMode(mode)}
                 className={`h-[42px] px-5 text-xs font-bold uppercase transition-all ${
                   importMode === mode
-                    ? "bg-[#FF6B00] text-black"
+                    ? "bg-[#FF6B00] text-[whitesmoke]"
                     : "bg-[#111] text-gray-400 hover:text-white"
                 }`}
               >
@@ -249,7 +249,7 @@ export default function Settings() {
               setSuccessMessage("Demo Data Loaded!");
               setTimeout(() => setSuccessMessage(""), 3000);
             }}
-            className="h-[48px] min-w-[240px] rounded-xl bg-[#FF6B00] px-8 text-sm font-black uppercase text-black"
+            className="h-[48px] min-w-[240px] rounded-xl bg-[#FF6B00] px-8 text-sm font-black uppercase text-[whitesmoke]"
           >
             Load Demo Data
           </button>
@@ -263,7 +263,7 @@ export default function Settings() {
         right={
           <button
             onClick={() => setShowManualEntry(!showManualEntry)}
-            className="rounded-xl border border-[#222] px-5 py-2 text-sm font-semibold uppercase text-gray-400"
+            className="rounded-xl border border-[#222] px-5 py-2 text-sm font-semibold uppercase text-[whitesmoke]"
           >
             {showManualEntry ? "Hide Form" : "Show Form"}
           </button>
@@ -400,7 +400,7 @@ export default function Settings() {
             <div className="flex gap-3">
               <button
                 type="submit"
-                className="rounded-xl bg-[#FF6B00] px-7 py-3 font-black uppercase text-black"
+                className="rounded-xl bg-[#FF6B00] px-7 py-3 font-black uppercase text-[whitesmoke]"
               >
                 Add Transaction
               </button>

--- a/src/pages/Transaction.jsx
+++ b/src/pages/Transaction.jsx
@@ -497,7 +497,7 @@ export default function Transaction() {
     </div>
   ) : (
     <div className="flex flex-col items-center justify-center h-full min-h-[60vh]">
-      <div className="retro-card p-12 flex flex-col items-center max-w-md text-center border-[#FF6B00]/30 shadow-[0_0_20px_rgba(255,107,0,0.1)] animate-in fade-in zoom-in-95 duration-500 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_24px_rgba(255,107,0,0.12)]">
+      <div className="retro-card p-12 flex flex-col items-center max-w-md text-center border-[#FF6B00]/20 animate-in fade-in zoom-in-95 duration-500 transition-all duration-300 hover:border-[#FF6B00]/28">
         <div className="w-16 h-16 bg-[#FF6B00]/10 flex items-center justify-center rounded-full mb-6 text-[#FF6B00]">
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/Transaction.jsx
+++ b/src/pages/Transaction.jsx
@@ -406,7 +406,7 @@ export default function Transaction() {
                 onClick={() => toggleCategory(category)}
                 className={`px-3 py-1 text-xs font-bold uppercase tracking-wider rounded-sm border transition-colors ${
                   selectedCategories.includes(category)
-                    ? "bg-[#FF6B00] text-black border-[#FF6B00]"
+                    ? "bg-[#FF6B00] text-[whitesmoke] border-[#FF6B00]"
                     : "bg-[#1F1F1F] text-gray-300 border-[#2a2a2a] hover:border-[#FF6B00]"
                 }`}
               >
@@ -428,7 +428,7 @@ export default function Transaction() {
         <div className="flex justify-end items-center px-4 pt-4">
           <button
             onClick={exportToCSV}
-            className="px-3 py-2 bg-[#FF6B00] text-black text-sm font-bold rounded-md hover:opacity-90 transition"
+            className="px-3 py-2 bg-[#FF6B00] text-[whitesmoke] text-sm font-bold rounded-md hover:opacity-90 transition"
           >
             Export CSV
           </button>


### PR DESCRIPTION
## Summary

Closes #114 

This PR introduces a theme-switching system with Light Mode and Dark Mode support. The selected theme is persisted using local storage and restored across sessions.

## Changes

* Added theme toggle (Light/Dark)
* Persisted theme preference in local storage
* Applied theme support across all pages and components
* Updated cards, buttons, forms, inputs, tables, modals, navigation, dashboard widgets, and typography
* Implemented Light Mode using the Lavender Purple + White design palette
* Ensured accessibility, contrast, and consistent interactive states
* Verified responsiveness across mobile, tablet, laptop, and desktop viewports

## Screenshot

<img width="1470" height="882" alt="image" src="https://github.com/user-attachments/assets/32ae7751-e8af-4347-bc1e-a4780e23900b" />


## Testing

* [x] Theme switching works correctly
* [x] Theme preference persists across sessions
* [x] Components render correctly in both themes
* [x] Responsive across supported screen sizes
