### PR TITLE
[BUG FIX] Month-on-Month Expenses insight card now displays real data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "react-papaparse": "^4.4.0",
         "react-router-dom": "^7.14.1",
         "recharts": "^3.8.1",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,8 @@
     "react-dropzone": "^15.0.0",
     "react-papaparse": "^4.4.0",
     "react-router-dom": "^7.14.1",
-    "recharts": "^3.8.1"
-    ,
-    "uuid": "^9.0.0"
+    "recharts": "^3.8.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/src/components/Insights/InsightCards.jsx
+++ b/src/components/Insights/InsightCards.jsx
@@ -75,6 +75,25 @@ export default function InsightCards({ transactions }) {
     const uniqueMonthsCount = Object.keys(monthlyData).length || 1;
     const avgMonthlyIncome = Math.round(income / uniqueMonthsCount);
 
+    // 5. Month-on-month expense change
+    const sortedMonths = Object.keys(monthlyData).sort((a, b) => {
+      return new Date(a) - new Date(b);
+    });
+
+    let monthOnMonthChange = null;
+    let prevMonthLabel = null;
+    if (sortedMonths.length >= 2) {
+      const currentMonth = sortedMonths[sortedMonths.length - 1];
+      const previousMonth = sortedMonths[sortedMonths.length - 2];
+      const currentExpense = monthlyData[currentMonth].expense;
+      const previousExpense = monthlyData[previousMonth].expense;
+      prevMonthLabel = previousMonth;
+
+      if (previousExpense > 0) {
+        monthOnMonthChange = Math.round(((currentExpense - previousExpense) / previousExpense) * 100);
+      }
+    }
+
     return { 
       topCategory, 
       topCatAmt, 
@@ -83,7 +102,9 @@ export default function InsightCards({ transactions }) {
       totalIncome: income, 
       totalExpenses: expenses, 
       mostActiveMonth, 
-      avgMonthlyIncome 
+      avgMonthlyIncome,
+      monthOnMonthChange,
+      prevMonthLabel
     };
   };
 
@@ -104,10 +125,20 @@ export default function InsightCards({ transactions }) {
     },
     {
       title: "MONTH-ON-MONTH EXPENSES",
-      value: "+99%", 
-      subtitle: "Spending rose vs February 2026. Review discretionary categories.",
+      value: metrics.monthOnMonthChange !== null
+        ? `${metrics.monthOnMonthChange > 0 ? "+" : ""}${metrics.monthOnMonthChange}%`
+        : "N/A",
+      subtitle: metrics.monthOnMonthChange !== null
+        ? metrics.monthOnMonthChange > 0
+          ? `Spending rose vs ${metrics.prevMonthLabel}. Review discretionary categories.`
+          : metrics.monthOnMonthChange < 0
+          ? `Spending dropped vs ${metrics.prevMonthLabel}. Great discipline!`
+          : `No change in spending vs ${metrics.prevMonthLabel}.`
+        : "Not enough data to calculate month-on-month change.",
       icon: <TrendingUp className="w-5 h-5 text-red-400" />,
-      valueClass: "text-red-500"
+      valueClass: metrics.monthOnMonthChange !== null && metrics.monthOnMonthChange > 0
+        ? "text-red-500"
+        : "text-green-500"
     },
     {
       title: "NET SAVINGS THIS MONTH",

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -35,9 +35,9 @@ export default function ProtectedRoute({ children }) {
     );
   }
 
-  // if (!user) {
-  //   return <Navigate to="/signin" replace />;
-  // }
+  if (!user) {
+    return <Navigate to="/signin" replace />;
+  }
 
   return children;
 }

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -35,9 +35,9 @@ export default function ProtectedRoute({ children }) {
     );
   }
 
-  if (!user) {
-    return <Navigate to="/signin" replace />;
-  }
+  // if (!user) {
+  //   return <Navigate to="/signin" replace />;
+  // }
 
   return children;
 }


### PR DESCRIPTION
## Description
Fixed the Month-on-Month Expenses insight card in `InsightCards.jsx` which was displaying hardcoded placeholder values (`+99%` and `"Spending rose vs February 2026"`) for every user regardless of their actual transaction data.

## Changes
- `src/components/Insights/InsightCards.jsx` — added real month-on-month calculation inside `processMetrics()` using the existing `monthlyData` object. Sorts months chronologically, compares the two most recent months' expenses, and calculates the real percentage change. Shows `N/A` with a helpful message when there is only one month of data.

##Screenshot
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/63613993-a32a-410d-9051-ec42e35ecc4a" />


## Related Issue
Closes #98 

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: @Kr1491
- Contribution level: Intermediate