### PR TITLE
style: implement warm light orange theme for improved contrast

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -37,25 +37,47 @@
 
 :root[data-theme="light"],
 body[data-theme="light"] {
-  --color-fin-bg: #fdfdfd;
-  --color-fin-surface: #ffffff;
-  --color-fin-surface-2: #f5f5f5;
-  --color-fin-surface-soft: rgba(255, 107, 0, 0.03);
-  --color-fin-border: #eaeaea;
-  --color-fin-border-strong: #d4d4d4;
-  --color-fin-border-soft: rgba(0, 0, 0, 0.08);
-  --color-fin-border-hover-soft: rgba(255, 107, 0, 0.18);
-  --color-fin-text: #171717;
-  --color-fin-muted: #666666;
-  --color-fin-accent: #FF6B00;
+  /* ── Layer 1: Main viewport / canvas ────────────────────────────────── */
+  /* orange-50 equivalent — warm cream base, never harsh white            */
+  --color-fin-bg:          #FFF7ED;
+  --color-fin-bg-elevated: #FFF7ED;
+
+  /* ── Layer 2: Sidebar & strong-panel backgrounds ────────────────────── */
+  /* orange-100 — one step richer, gives structural depth vs the canvas   */
+  --color-fin-surface-2:   #FFEDD5;
+
+  /* ── Layer 3: Floating cards, modals, dropdowns ─────────────────────── */
+  /* Pure white so cards "pop" cleanly above the cream backdrop           */
+  --color-fin-surface:     #FFFFFF;
+  --color-fin-surface-soft: rgba(255, 107, 0, 0.04);
+
+  /* ── Borders ────────────────────────────────────────────────────────── */
+  /* orange-200 — warm, not cold grey                                     */
+  --color-fin-border:           #FED7AA;
+  /* amber-300 — sidebar right-border / strong dividers                   */
+  --color-fin-border-strong:    #FCD34D;
+  --color-fin-border-soft:      rgba(255, 107, 0, 0.10);
+  --color-fin-border-hover-soft: rgba(255, 107, 0, 0.22);
+  --color-fin-border-hover:     var(--color-fin-accent);
+
+  /* ── Typography ─────────────────────────────────────────────────────── */
+  /* Primary — near-black for max legibility                              */
+  --color-fin-text:         #1C1412;
+  /* Secondary / muted — orange-900 warm dark brown, WCAG AA on #FFF7ED  */
+  --color-fin-muted:        #7C2D12;
+
+  /* ── Accent (unchanged — orange brand stays consistent) ─────────────── */
+  --color-fin-accent:        #FF6B00;
   --color-fin-accent-strong: #FF8C00;
-  --color-fin-border-hover: var(--color-fin-accent);
-  --color-fin-accent-soft: rgba(255, 107, 0, 0.12);
-  --color-fin-accent-rgb: 255, 107, 0;
-  --color-fin-shadow: rgba(0, 0, 0, 0.08);
-  --color-fin-shadow-accent: rgba(255, 107, 0, 0.2);
-  --color-fin-bg-elevated: #ffffff;
-  --color-fin-text-inverse: #ffffff;
+  --color-fin-accent-soft:   rgba(255, 107, 0, 0.13);
+  --color-fin-accent-rgb:    255, 107, 0;
+
+  /* ── Shadows — warm amber-tinted, diffused ───────────────────────────── */
+  --color-fin-shadow:        rgba(124, 45, 18, 0.06);
+  --color-fin-shadow-accent: rgba(255, 107, 0, 0.18);
+
+  /* ── Inverse (text on orange accent buttons) ─────────────────────────── */
+  --color-fin-text-inverse:  #FFFFFF;
 }
 
 body {
@@ -76,10 +98,10 @@ body {
 
 body[data-theme="light"] {
   background-image:
-    radial-gradient(ellipse at 20% 20%, rgba(var(--color-fin-accent-rgb), 0.05) 0%, transparent 52%),
-    radial-gradient(ellipse at 80% 80%, rgba(var(--color-fin-accent-rgb), 0.03) 0%, transparent 52%),
-    linear-gradient(rgba(0, 0, 0, 0.03) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+    radial-gradient(ellipse at 20% 20%, rgba(var(--color-fin-accent-rgb), 0.06) 0%, transparent 52%),
+    radial-gradient(ellipse at 80% 80%, rgba(var(--color-fin-accent-rgb), 0.04) 0%, transparent 52%),
+    linear-gradient(rgba(124, 45, 18, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(124, 45, 18, 0.025) 1px, transparent 1px);
 }
 
 button,
@@ -175,8 +197,6 @@ body[data-theme="light"] [class*="bg-[#FFA500]/"] {
 }
 
 body[data-theme="light"] .theme-panel,
-body[data-theme="light"] .theme-sidebar,
-body[data-theme="light"] .theme-header,
 body[data-theme="light"] .fin-card,
 body[data-theme="light"] .retro-card,
 body[data-theme="light"] .fin-metric-card,
@@ -189,9 +209,14 @@ body[data-theme="light"] .auth-social-btn {
   color: var(--color-fin-text) !important;
 }
 
+/* Sidebar and header sit at the structural layer (orange-100), not card-white */
+body[data-theme="light"] .theme-sidebar {
+  background: var(--color-fin-surface-2) !important;
+  border-color: var(--color-fin-border-strong) !important;
+  color: var(--color-fin-text) !important;
+}
+
 body[data-theme="light"] .theme-panel-strong,
-body[data-theme="light"] .theme-sidebar,
-body[data-theme="light"] .theme-header,
 body[data-theme="light"] .profile-dropdown {
   background-color: var(--color-fin-bg) !important;
 }
@@ -248,7 +273,7 @@ body[data-theme="light"] .theme-route-loader div {
 }
 
 body[data-theme="light"] .theme-overlay {
-  background: rgba(255, 255, 255, 0.72) !important;
+  background: rgba(255, 235, 210, 0.75) !important;
 }
 
 body[data-theme="light"] .theme-overlay-card {
@@ -256,18 +281,33 @@ body[data-theme="light"] .theme-overlay-card {
 }
 
 body[data-theme="light"] ::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: #FFF7ED;
 }
 
 body[data-theme="light"] ::-webkit-scrollbar-thumb {
-  background: #d4d4d4;
+  background: #FED7AA;
 }
 
 body[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
   background: var(--color-fin-accent);
 }
 
-/* ── Light mode profile styling ──────────────────────────────────────────────── */
+/* ── Light mode: premium ambient shadows on cards ──────────────────────── */
+body[data-theme="light"] .fin-card,
+body[data-theme="light"] .retro-card,
+body[data-theme="light"] .fin-metric-card {
+  box-shadow:
+    0 4px 20px -2px rgba(124, 45, 18, 0.06),
+    0 2px 8px -1px rgba(124, 45, 18, 0.04) !important;
+}
+
+body[data-theme="light"] .fin-card:hover,
+body[data-theme="light"] .retro-card:hover,
+body[data-theme="light"] .fin-metric-card:hover {
+  box-shadow:
+    0 8px 28px -4px rgba(124, 45, 18, 0.09),
+    0 4px 12px -2px rgba(124, 45, 18, 0.06) !important;
+}
 body[data-theme="light"] .profile-avatar {
   color: #ffffff;
   background: linear-gradient(135deg, var(--color-fin-accent) 0%, var(--color-fin-accent-strong) 100%);
@@ -291,8 +331,9 @@ body[data-theme="light"] .profile-dropdown {
   background: var(--color-fin-surface);
   border: 1px solid var(--color-fin-border);
   box-shadow:
-    0 16px 48px rgba(0, 0, 0, 0.08),
-    0 0 0 1px rgba(0, 0, 0, 0.04);
+    0 12px 40px -4px rgba(124, 45, 18, 0.10),
+    0 4px 16px -2px rgba(124, 45, 18, 0.06),
+    0 0 0 1px rgba(124, 45, 18, 0.04);
 }
 
 body[data-theme="light"] .profile-dropdown::before {
@@ -332,7 +373,7 @@ body[data-theme="light"] .profile-dropdown-item:hover {
 body[data-theme="light"] input,
 body[data-theme="light"] select,
 body[data-theme="light"] textarea {
-  background-color: white !important;
+  background-color: var(--color-fin-surface) !important;
   color: var(--color-fin-text) !important;
   border-color: var(--color-fin-border) !important;
 }
@@ -340,7 +381,7 @@ body[data-theme="light"] textarea {
 body[data-theme="light"] input:focus,
 body[data-theme="light"] select:focus,
 body[data-theme="light"] textarea:focus {
-  background-color: white !important;
+  background-color: var(--color-fin-surface) !important;
   border-color: var(--color-fin-accent) !important;
   box-shadow: 0 0 0 3px rgba(var(--color-fin-accent-rgb), 0.1) !important;
 }
@@ -352,7 +393,7 @@ body[data-theme="light"] textarea::placeholder {
 
 /* Ensure option elements display correctly */
 body[data-theme="light"] option {
-  background-color: white !important;
+  background-color: var(--color-fin-surface) !important;
   color: var(--color-fin-text) !important;
 }
 
@@ -398,7 +439,7 @@ body[data-theme="light"] button[class*="text-black"] {
 
 /* Fix: File inputs */
 body[data-theme="light"] .file-input {
-  background-color: white !important;
+  background-color: var(--color-fin-surface) !important;
   color: var(--color-fin-text) !important;
   border-color: var(--color-fin-border) !important;
 }
@@ -422,13 +463,13 @@ body[data-theme="light"] .text-zinc-600 {
 
 /* Fix: Progress bar background in light mode */
 body[data-theme="light"] div.bg-zinc-900 {
-  background-color: #e5e5e5 !important;
-  border-color: #d4d4d4 !important;
+  background-color: #FFEDD5 !important;
+  border-color: var(--color-fin-border) !important;
 }
 
 /* Fix: Scrollbar color in light mode */
 body[data-theme="light"] ::-webkit-scrollbar-thumb {
-  background: #d4d4d4 !important;
+  background: #FED7AA !important;
 }
 
 .fin-card {
@@ -1108,9 +1149,22 @@ body[data-theme="light"] ::-webkit-scrollbar-thumb {
   border-bottom: 1px solid var(--color-fin-border);
 }
 
+body[data-theme="light"] .theme-header {
+  background: rgba(255, 247, 237, 0.88) !important;
+  border-bottom: 1px solid var(--color-fin-border) !important;
+  backdrop-filter: blur(12px);
+}
+
 .theme-sidebar {
   background: linear-gradient(180deg, var(--color-fin-surface) 0%, var(--color-fin-bg) 100%);
   border-right: 1px solid var(--color-fin-border);
+}
+
+body[data-theme="light"] .theme-sidebar {
+  /* orange-100 — distinct structural layer, clearly richer than the canvas */
+  background: linear-gradient(180deg, #FFEDD5 0%, #FFE4C8 100%) !important;
+  /* amber-300 right border — crisp warm separator vs the cream canvas     */
+  border-right: 1px solid #FCD34D !important;
 }
 
 .theme-icon-button {


### PR DESCRIPTION
### Associated Issue
Closes #199 

### Description
As proposed in the linked issue, this PR overhauls the default light theme profile to transition it from a flat, stark white layout into a cohesive, tiered Light Orange/Cream theme ecosystem. 

### Changes Made
* **Workspace Canvas:** Shifted the main dashboard background to a soft, soothing warm cream color to eliminate eye strain.
* **Layout Segmentation:** Assigned a richer cream tone to the navigation sidebar, providing instant structure and visual depth.
* **Component Elevation:** Kept the metric cards and data charts pure white so they cleanly "float" over the new background profile without bleeding together.

### Visual Proof (Before vs. After)
| Before (Stark White) | After (Light Orange Refactor) |
| :--- | :--- |

<img width="370" height="200" alt="Screenshot 2026-06-09 004454" src="https://github.com/user-attachments/assets/cba55927-7479-4a16-aecf-07e3e2f80814" /><img width="370" height="200" alt="Screenshot 2026-06-09 004510" src="https://github.com/user-attachments/assets/92d287c7-e890-46b8-826c-1bd9ae01732b" />
 

### Checklist
- [x] My code follows the code style of this project.
- [x] The changes reflect correctly on local development servers.
- [x] No unrelated files (like `App.jsx` or `.env`) are tracked in this PR.