### PR TITLE
fix: remove duplicate nav items and header theme toggle resolves #209

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,13 +1,12 @@
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../../context/useAuth";
-import { useTheme } from "../../context/ThemeContext";
 import { useState, useRef, useEffect } from "react";
-import { LogOut, ChevronDown, MoonStar, SunMedium, User, Settings } from "lucide-react";
+import { LogOut, ChevronDown, User, Settings } from "lucide-react";
 export default function Header() {
   const location = useLocation();
   const navigate = useNavigate();
   const { user, signOut } = useAuth();
-  const { theme, toggleTheme } = useTheme();
+
 
   const [profileOpen, setProfileOpen] = useState(false);
   const dropdownRef = useRef(null);

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -86,15 +86,6 @@ export default function Header() {
         <p className="text-xs text-[var(--color-fin-muted)] leading-tight">{getPageSubtitle()}</p>
       </div>
 
-      <button
-        type="button"
-        onClick={toggleTheme}
-        className="theme-toggle-button ml-auto inline-flex items-center rounded-full px-3 py-2 transition-all duration-200"
-        aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
-      >
-        {theme === 'dark' ? <SunMedium size={14} /> : <MoonStar size={14} />}
-      </button>
-
       {/* ── Profile section ──────────────────────────────────────── */}
       <div className="flex items-center gap-3 relative" ref={dropdownRef}>
         <button

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -23,8 +23,6 @@ export default function Sidebar() {
     { name: "Transactions", to: "/transaction", icon: ArrowLeftRight },
     { name: "Insights", to: "/insights", icon: BarChart2 },
     { name: "Settings", to: "/settings", icon: Settings },
-    { name: "Profile", to: "/profile", icon: UserCircle },
-    { name: "Preferences", to: "/preferences", icon: SlidersHorizontal },
   ];
 
   return (

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -8,8 +8,6 @@ import {
   BarChart2,
   Settings,
   Target,
-  UserCircle,
-  SlidersHorizontal,
 } from "lucide-react";
 
 export default function Sidebar() {

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -7,7 +7,7 @@ import { normalizeTransactions } from "../lib/transactionNormalizer";
 import { format } from "date-fns";
 import { useModal } from "../context/ModalContext";
 import { supabase } from "../lib/supabaseClient";
-import { useAuth } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 import { Database, Upload, PenLine, Coins, AlertTriangle, Trash2, CheckCircle2 } from "lucide-react";
 
 // =========================


### PR DESCRIPTION
Closes #209

### Changes Made
- Removed dark mode/theme toggle button from the header
- Removed Profile navigation item from the sidebar
- Removed Preferences navigation item from the sidebar

Profile, Preferences, and theme settings remain fully accessible 
through the user profile dropdown in the top-right corner.
