### PR TITLE
fix(AppContext): handle Supabase errors in transaction operations to prevent client-server state inconsistency

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -115,7 +115,11 @@ export function AppContext({ children }) {
     const txToDelete = typeof indexOrId === 'number' ? transactions[indexOrId] : transactions.find(t => t.id === indexOrId);
     
     if (txToDelete && txToDelete.id && user) {
-      await supabase.from('transactions').delete().eq('id', txToDelete.id);
+      const { error } = await supabase.from('transactions').delete().eq('id', txToDelete.id);
+      if (error) {
+        console.error('Error deleting transaction:', error);
+        throw error;
+      }
     }
     
     const updated = typeof indexOrId === 'number' 
@@ -132,7 +136,7 @@ export function AppContext({ children }) {
     });
 
     if (user) {
-      const { data } = await supabase.from('transactions').insert({
+      const { data, error } = await supabase.from('transactions').insert({
         user_id: user.id,
         date: normalized.Date,
         amount: normalized.Amount,
@@ -140,6 +144,11 @@ export function AppContext({ children }) {
         category: normalized.category,
         currency: normalized.Currency
       }).select().single();
+      
+      if (error) {
+        console.error('Error adding transaction:', error);
+        throw error;
+      }
       
       if (data) {
         normalized.id = data.id;
@@ -163,13 +172,18 @@ export function AppContext({ children }) {
     const targetTx = transactions[index];
     if (targetTx && targetTx.id && user) {
       normalized.id = targetTx.id;
-      await supabase.from('transactions').update({
+      const { error } = await supabase.from('transactions').update({
         date: normalized.Date,
         amount: normalized.Amount,
         description: normalized.Description,
         category: normalized.category,
         currency: normalized.Currency
       }).eq('id', targetTx.id);
+
+      if (error) {
+        console.error('Error updating transaction:', error);
+        throw error;
+      }
     }
 
     setTransactions((prev) => prev.map((t, i) => i === index ? normalized : t));


### PR DESCRIPTION
### **Summary**

Closes #222 

This PR improves reliability in `src/context/AppContext.jsx` by ensuring that transaction operations properly handle Supabase errors before updating local state.

Previously, the app used optimistic updates without confirming whether Supabase requests succeeded, which could lead to mismatches between the UI and the database.

---

### **Changes Made**

* Updated `deleteTransaction`, `addTransaction`, and `updateTransaction` methods
* All Supabase calls are now properly awaited
* Explicit error checking added for Supabase responses
* If an error occurs:

  * The error is logged
  * The function throws immediately
  * Local state (`setTransactions`) is **not updated**
* Prevents UI from reflecting failed backend operations

---

### **Why This Matters**

* Ensures **data consistency between frontend and Supabase**
* Prevents users from seeing transactions that were not actually saved
* Improves reliability during:

  * Network failures
  * Database errors
  * Validation failures
* Reduces risk of silent data corruption or mismatch

---

### **Behavior Change**

* Before: UI updated even if Supabase failed ❌
* Now: UI updates only after successful Supabase operation ✅

---

### **Testing**

* Simulate network failure → transaction should not appear in UI
* Force Supabase error → state should remain unchanged
* Successful operations → behave normally

---

### **Impact**

* Improved data integrity
* More predictable application state
* Safer transaction handling flow

