### PR TITLE
enhancement: highlight project contributors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Before opening an issue or submitting a pull request, please review:
 * [CONTRIBUTING.md](./CONTRIBUTING.md)
 * [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
 
+### 👥 Contributors
+
+Thanks to all contributors ❤️
+
+[![Contributors](https://contrib.rocks/image?repo=khanirfan18/finBoard)](https://github.com/khanirfan18/finBoard/graphs/contributors)
+
 ### Guidelines
 
 Happy building 🚀


### PR DESCRIPTION
## Description

Added a new **Contributors** section to the README to acknowledge and showcase all project contributors.

### Changes Made
- Added a dedicated **👥 Contributors** section.
- Integrated the **Contrib.rocks** contributors image.
- Linked the contributors image to the GitHub contributors graph.
- Improved community visibility and contributor recognition.

### Before
No contributor showcase section was present in the README.

### After
A contributors section is displayed in the README with automatically updated contributor avatars and a link to the contributors page.

### Related Issue
Closes #229 