### PR TITLE
refactor: guard console.error calls behind DEV environment check

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -3,7 +3,7 @@ import normalizeTransaction, { normalizeTransactions } from '../lib/transactionN
 import { supabase } from '../lib/supabaseClient';
 import { useAuth } from './useAuth';
 import { DataContext } from './DataContext';
-import {CURRENCIES} from '../lib/Currencies'
+import { CURRENCIES } from '../lib/Currencies'
 
 export function AppContext({ children }) {
   const { user } = useAuth();
@@ -33,7 +33,11 @@ export function AppContext({ children }) {
         setCurrencySymbols(symbols);
         setExchangeRates(data.rates);
       })
-      .catch((err) => console.error(err));
+      .catch((err) => {
+        if (import.meta.env.DEV) {
+          console.error(err);
+        }
+      });
   }, []);
 
   React.useEffect(() => {
@@ -46,14 +50,14 @@ export function AppContext({ children }) {
       }
 
       setLoadingData(true);
-      
+
       try {
         const { data: settingsData } = await supabase
           .from('user_settings')
           .select('currency')
           .eq('user_id', user.id)
           .single();
-          
+
         if (settingsData && settingsData.currency) {
           setCurrency(settingsData.currency);
         } else {
@@ -68,7 +72,7 @@ export function AppContext({ children }) {
           .select('*')
           .eq('user_id', user.id)
           .order('created_at', { ascending: true });
-          
+
         if (txData) {
           const mappedTx = txData.map(t => ({
             id: t.id,
@@ -78,17 +82,19 @@ export function AppContext({ children }) {
             category: t.category,
             Currency: t.currency
           }));
-          
+
           const normalized = normalizeTransactions(mappedTx, { currency: settingsData?.currency || CURRENCIES[0] });
           setTransactions(normalized);
         }
       } catch (err) {
-        console.error('Error loading data from Supabase:', err);
+        if (import.meta.env.DEV) {
+          console.error('Error loading data from Supabase:', err);
+        }
       } finally {
         setLoadingData(false);
       }
     }
-    
+
     loadData();
   }, [user]);
 
@@ -113,15 +119,15 @@ export function AppContext({ children }) {
 
   const deleteTransaction = async (indexOrId) => {
     const txToDelete = typeof indexOrId === 'number' ? transactions[indexOrId] : transactions.find(t => t.id === indexOrId);
-    
+
     if (txToDelete && txToDelete.id && user) {
       await supabase.from('transactions').delete().eq('id', txToDelete.id);
     }
-    
-    const updated = typeof indexOrId === 'number' 
+
+    const updated = typeof indexOrId === 'number'
       ? transactions.filter((_, i) => i !== indexOrId)
       : transactions.filter((t) => t.id !== indexOrId);
-      
+
     setTransactions(updated);
   };
 
@@ -140,7 +146,7 @@ export function AppContext({ children }) {
         category: normalized.category,
         currency: normalized.Currency
       }).select().single();
-      
+
       if (data) {
         normalized.id = data.id;
       }
@@ -151,7 +157,7 @@ export function AppContext({ children }) {
 
   const updateTransaction = async (index, updatedTransaction) => {
     const originalCurrency = transactions[index]?.Currency || currency;
-    
+
     const normalized = normalizeTransaction({
       ...updatedTransaction,
       Currency: originalCurrency,
@@ -177,16 +183,16 @@ export function AppContext({ children }) {
 
   const displayTransactions = React.useMemo(() => {
     if (!transactions) return [];
-    
+
     return transactions.map((t) => {
       let convertedAmt = t.Amount;
-      
+
       if (exchangeRates && t.Currency?.code !== currency.code) {
         const origCode = t.Currency?.code || currency.code;
         const rateOrigToUSD = 1 / (exchangeRates[origCode] || 1);
         const rateUSDToTarget = exchangeRates[currency.code] || 1;
         const conversionRate = rateOrigToUSD * rateUSDToTarget;
-        
+
         const parsed = Number(t.Amount);
         if (!isNaN(parsed)) {
           convertedAmt = parsed * conversionRate;

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -45,7 +45,9 @@ export function AuthProvider({ children }) {
         setUser(currentSession?.user ?? null);
         setAuthError('');
       } catch (error) {
-        console.error('Unexpected error while loading the Supabase session:', error);
+        if (import.meta.env.DEV) {
+          console.error('Unexpected error while loading the Supabase session:', error);
+        }
 
         if (!isMounted) {
           return;
@@ -89,7 +91,9 @@ export function AuthProvider({ children }) {
       const { error } = await supabase.auth.signOut();
 
       if (error) {
-        console.error('Supabase signOut failed:', error);
+        if (import.meta.env.DEV) {
+          console.error('Supabase signOut failed:', error);
+        }
         setAuthError(
           getFriendlyAuthError(error, 'We could not sign you out right now. Please try again.')
         );
@@ -101,7 +105,9 @@ export function AuthProvider({ children }) {
       setAuthError('');
       return true;
     } catch (error) {
-      console.error('Unexpected error during signOut:', error);
+      if (import.meta.env.DEV) {
+        console.error('Unexpected error during signOut:', error);
+      }
       setAuthError('We could not sign you out right now. Please try again.');
       return false;
     }


### PR DESCRIPTION
## Related Issue

Closes #212

---

## Summary

This PR updates the context files to ensure `console.error()` is only executed during development. The logs are now wrapped with `import.meta.env.DEV`, preventing unnecessary error output in production while keeping the same debugging experience during local development.

---

## Changes

### `src/context/AppContext.jsx`

* Wrapped the `console.error` call in the exchange rates fetch `.catch()` block.
* Wrapped the `console.error` call in the Supabase `loadData` catch block.

### `src/context/AuthContext.jsx`

* Wrapped the `console.error` call in the `loadSession` catch block.
* Wrapped the `console.error` call in the `signOut` error handling block.
* Wrapped the `console.error` call in the `signOut` catch block.

---

## What Stayed the Same

* User-facing error handling remains unchanged (`setAuthError`, `setSession(null)`, `return false`, etc.).
* The existing catch blocks and control flow are untouched.
* This change only affects when error logs are printed.

---

## Implementation

Before:

```js
console.error(error);
```

After:

```js
if (import.meta.env.DEV) {
  console.error(error);
}
```

`import.meta.env.DEV` is Vite's built-in environment flag. It evaluates to `true` while running the development server and `false` in production builds, so console error logs are automatically omitted from production.

---

## Type of Change

* [x] Refactor (no functional changes)
