### PR TITLE
feat: add freemium auth gating for Budgets and Goals

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -89,25 +89,39 @@ export default function App() {
                 />
                 <Route path="/reset-password" element={<ResetPassword />} />
 
-                {/* Protected routes */}
-                <Route
-                  path="/"
-                  element={
-                    <ProtectedRoute>
-                      <Layout />
-                    </ProtectedRoute>
-                  }
-                >
+                {/* App shell — free routes are guest-accessible; premium routes are gated */}
+                <Route path="/" element={<Layout />}>
                   <Route index element={<Dashboard />} />
                   <Route path="dashboard" element={<Dashboard />} />
-                  <Route path="budgets" element={<Budgets />} />
                   <Route path="settings" element={<Settings />} />
                   <Route path="transaction" element={<Transaction />} />
                   <Route path="insights" element={<InsightsDashboard />} />
-                  <Route path="goals" element={<Goals />} />
-                  <Route path="profile" element={<Profile />} />
                   <Route path="preferences" element={<Preferences />} />
                   <Route path="help" element={<HelpCenter />} />
+                  <Route
+                    path="budgets"
+                    element={
+                      <ProtectedRoute>
+                        <Budgets />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="goals"
+                    element={
+                      <ProtectedRoute>
+                        <Goals />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="profile"
+                    element={
+                      <ProtectedRoute>
+                        <Profile />
+                      </ProtectedRoute>
+                    }
+                  />
                 </Route>
               </Routes>
             </BrowserRouter>

--- a/src/components/GuestRoute.jsx
+++ b/src/components/GuestRoute.jsx
@@ -1,12 +1,14 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/useAuth';
 
 /**
- * Wraps guest-only routes — redirects to /dashboard when there is an active session.
+ * Wraps guest-only routes — redirects authenticated users away from sign-in/sign-up.
+ * Honors location.state.from when present so post-login destinations are preserved.
  * Shows nothing while the auth state is still loading to avoid a flash of content.
  */
 export default function GuestRoute({ children }) {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -35,7 +37,10 @@ export default function GuestRoute({ children }) {
   }
 
   if (user) {
-    return <Navigate to="/dashboard" replace />;
+    const from = location.state?.from;
+    const destination =
+      from && typeof from.pathname === 'string' ? from.pathname : '/dashboard';
+    return <Navigate to={destination} replace />;
   }
 
   return children;

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,13 +1,17 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/useAuth';
+
+const PREMIUM_PATHS = ['/budgets', '/goals'];
 
 /**
  * Wraps protected routes — redirects to /signin when there is no active session.
+ * Preserves the intended route in location state for post-login continuation.
  * Shows nothing while the auth state is still loading to avoid a flash of the
  * sign-in page on hard refresh.
  */
 export default function ProtectedRoute({ children }) {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -36,7 +40,15 @@ export default function ProtectedRoute({ children }) {
   }
 
   if (!user) {
-    return <Navigate to="/signin" replace />;
+    const isPremium = PREMIUM_PATHS.includes(location.pathname);
+    const search = isPremium ? '?reason=budgets-goals' : '';
+    return (
+      <Navigate
+        to={`/signin${search}`}
+        replace
+        state={{ from: location }}
+      />
+    );
   }
 
   return children;

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -2,15 +2,14 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../../context/useAuth";
 import { useState, useRef, useEffect } from "react";
 import { LogOut, ChevronDown, User, Settings } from "lucide-react";
+
 export default function Header() {
   const location = useLocation();
   const navigate = useNavigate();
   const { user, signOut } = useAuth();
 
-
   const [profileOpen, setProfileOpen] = useState(false);
   const dropdownRef = useRef(null);
-
 
   useEffect(() => {
     const handleClickOutside = (e) => {
@@ -85,84 +84,106 @@ export default function Header() {
         <p className="text-xs text-[var(--color-fin-muted)] leading-tight">{getPageSubtitle()}</p>
       </div>
 
-      {/* ── Profile section ──────────────────────────────────────── */}
+      {/* ── Auth / Profile section ─────────────────────────────────── */}
       <div className="flex items-center gap-3 relative ml-auto" ref={dropdownRef}>
-        <button
-          onClick={() => setProfileOpen(!profileOpen)}
-          className="profile-trigger"
-          id="profile-menu-btn"
-        >
-          {/* Avatar */}
-          <div className="profile-avatar">
-            {initials}
-          </div>
-          {/* Name (hidden on mobile) */}
-          <span className="profile-name hidden md:block">{displayName}</span>
-          <ChevronDown
-            size={14}
-            className="profile-chevron hidden md:block"
-            style={{
-              transform: profileOpen ? "rotate(180deg)" : "rotate(0deg)",
-              transition: "transform 0.2s ease",
-              color: "var(--color-fin-muted)",
-            }}
-          />
-        </button>
-
-        {/* Dropdown */}
-        {profileOpen && (
-          <div className="profile-dropdown animate-in">
-            {/* Gradient top bar */}
-            <div className="h-1 w-full rounded-t-xl mb-3"
-              style={{ background: "linear-gradient(90deg, var(--color-fin-accent), #f97316)" }} />
-
-            {/* User info */}
-            <div className="profile-dropdown-header">
-              <div className="w-10 h-10 rounded-xl flex items-center justify-center text-sm font-bold text-white shrink-0"
-                style={{ background: "linear-gradient(135deg, var(--color-fin-accent), #f97316)" }}>
+        {!user ? (
+          <>
+            <button
+              type="button"
+              onClick={() => navigate("/signin")}
+              className="text-sm font-semibold text-[var(--color-fin-muted)] hover:text-[var(--color-fin-text)] transition-colors px-2 py-1.5"
+              id="guest-signin-btn"
+            >
+              Sign in
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate("/signup")}
+              className="text-sm font-bold px-3 py-1.5 rounded-lg text-[var(--color-fin-text)] transition-colors"
+              style={{
+                background: "var(--color-fin-accent-soft)",
+                border: "1px solid color-mix(in srgb, var(--color-fin-accent) 35%, transparent)",
+              }}
+              id="guest-signup-btn"
+            >
+              Sign up
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              onClick={() => setProfileOpen(!profileOpen)}
+              className="profile-trigger"
+              id="profile-menu-btn"
+            >
+              <div className="profile-avatar">
                 {initials}
               </div>
-              <div className="profile-dropdown-info">
-                <span className="profile-dropdown-name">{displayName}</span>
-                <span className="profile-dropdown-email">{displayEmail}</span>
-              </div>
-            </div>
-
-            <div className="profile-dropdown-divider" />
-
-            <button
-              onClick={() => { setProfileOpen(false); navigate("/profile"); }}
-              className="profile-dropdown-item flex items-center gap-3 group"
-            >
-              <div className="p-1.5 rounded-lg bg-[var(--color-fin-accent)]/10 group-hover:bg-[var(--color-fin-accent)]/20 transition-colors">
-                <User size={14} className="text-[var(--color-fin-accent)]" />
-              </div>
-              View Profile
+              <span className="profile-name hidden md:block">{displayName}</span>
+              <ChevronDown
+                size={14}
+                className="profile-chevron hidden md:block"
+                style={{
+                  transform: profileOpen ? "rotate(180deg)" : "rotate(0deg)",
+                  transition: "transform 0.2s ease",
+                  color: "var(--color-fin-muted)",
+                }}
+              />
             </button>
 
-            <button
-              onClick={() => { setProfileOpen(false); navigate("/preferences"); }}
-              className="profile-dropdown-item flex items-center gap-3 group"
-            >
-              <div className="p-1.5 rounded-lg bg-blue-400/10 group-hover:bg-blue-400/20 transition-colors">
-                <Settings size={14} className="text-blue-400" />
-              </div>
-              Preferences
-            </button>
+            {profileOpen && (
+              <div className="profile-dropdown animate-in">
+                <div className="h-1 w-full rounded-t-xl mb-3"
+                  style={{ background: "linear-gradient(90deg, var(--color-fin-accent), #f97316)" }} />
 
-            <div className="profile-dropdown-divider" />
+                <div className="profile-dropdown-header">
+                  <div className="w-10 h-10 rounded-xl flex items-center justify-center text-sm font-bold text-white shrink-0"
+                    style={{ background: "linear-gradient(135deg, var(--color-fin-accent), #f97316)" }}>
+                    {initials}
+                  </div>
+                  <div className="profile-dropdown-info">
+                    <span className="profile-dropdown-name">{displayName}</span>
+                    <span className="profile-dropdown-email">{displayEmail}</span>
+                  </div>
+                </div>
 
-            <button
-              onClick={handleSignOut}
-              className="profile-dropdown-item profile-dropdown-item--danger flex items-center gap-3 group"
-              id="signout-btn"
-            >
-              <div className="p-1.5 rounded-lg bg-red-400/10 group-hover:bg-red-400/20 transition-colors">
-                <LogOut size={14} className="text-red-400" />
+                <div className="profile-dropdown-divider" />
+
+                <button
+                  onClick={() => { setProfileOpen(false); navigate("/profile"); }}
+                  className="profile-dropdown-item flex items-center gap-3 group"
+                >
+                  <div className="p-1.5 rounded-lg bg-[var(--color-fin-accent)]/10 group-hover:bg-[var(--color-fin-accent)]/20 transition-colors">
+                    <User size={14} className="text-[var(--color-fin-accent)]" />
+                  </div>
+                  View Profile
+                </button>
+
+                <button
+                  onClick={() => { setProfileOpen(false); navigate("/preferences"); }}
+                  className="profile-dropdown-item flex items-center gap-3 group"
+                >
+                  <div className="p-1.5 rounded-lg bg-blue-400/10 group-hover:bg-blue-400/20 transition-colors">
+                    <Settings size={14} className="text-blue-400" />
+                  </div>
+                  Preferences
+                </button>
+
+                <div className="profile-dropdown-divider" />
+
+                <button
+                  onClick={handleSignOut}
+                  className="profile-dropdown-item profile-dropdown-item--danger flex items-center gap-3 group"
+                  id="signout-btn"
+                >
+                  <div className="p-1.5 rounded-lg bg-red-400/10 group-hover:bg-red-400/20 transition-colors">
+                    <LogOut size={14} className="text-red-400" />
+                  </div>
+                  Sign out
+                </button>
               </div>
-              Sign out
-            </button>
-          </div>
+            )}
+          </>
         )}
       </div>
     </header>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -3,6 +3,129 @@ import { useAuth } from "../../context/useAuth";
 import { useState, useRef, useEffect } from "react";
 import { LogOut, ChevronDown, User, Settings } from "lucide-react";
 
+function GuestAuthButtons({ onSignIn, onSignUp }) {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onSignIn}
+        className="text-sm font-semibold text-[var(--color-fin-muted)] hover:text-[var(--color-fin-text)] transition-colors px-2 py-1.5"
+        id="guest-signin-btn"
+      >
+        Sign in
+      </button>
+      <button
+        type="button"
+        onClick={onSignUp}
+        className="text-sm font-bold px-3 py-1.5 rounded-lg text-[var(--color-fin-text)] transition-colors"
+        style={{
+          background: "var(--color-fin-accent-soft)",
+          border: "1px solid color-mix(in srgb, var(--color-fin-accent) 35%, transparent)",
+        }}
+        id="guest-signup-btn"
+      >
+        Sign up
+      </button>
+    </>
+  );
+}
+
+function AuthenticatedProfileMenu({
+  displayName,
+  displayEmail,
+  initials,
+  profileOpen,
+  setProfileOpen,
+  onViewProfile,
+  onPreferences,
+  onSignOut,
+}) {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setProfileOpen(!profileOpen)}
+        className="profile-trigger"
+        id="profile-menu-btn"
+        aria-expanded={profileOpen}
+        aria-haspopup="menu"
+      >
+        <div className="profile-avatar">{initials}</div>
+        <span className="profile-name hidden md:block">{displayName}</span>
+        <ChevronDown
+          size={14}
+          className="profile-chevron hidden md:block"
+          style={{
+            transform: profileOpen ? "rotate(180deg)" : "rotate(0deg)",
+            transition: "transform 0.2s ease",
+            color: "var(--color-fin-muted)",
+          }}
+        />
+      </button>
+
+      {profileOpen && (
+        <div className="profile-dropdown animate-in" role="menu">
+          <div
+            className="h-1 w-full rounded-t-xl mb-3"
+            style={{ background: "linear-gradient(90deg, var(--color-fin-accent), #f97316)" }}
+          />
+
+          <div className="profile-dropdown-header">
+            <div
+              className="w-10 h-10 rounded-xl flex items-center justify-center text-sm font-bold text-white shrink-0"
+              style={{ background: "linear-gradient(135deg, var(--color-fin-accent), #f97316)" }}
+            >
+              {initials}
+            </div>
+            <div className="profile-dropdown-info">
+              <span className="profile-dropdown-name">{displayName}</span>
+              <span className="profile-dropdown-email">{displayEmail}</span>
+            </div>
+          </div>
+
+          <div className="profile-dropdown-divider" />
+
+          <button
+            type="button"
+            onClick={onViewProfile}
+            className="profile-dropdown-item flex items-center gap-3 group"
+          >
+            <div className="p-1.5 rounded-lg bg-[var(--color-fin-accent)]/10 group-hover:bg-[var(--color-fin-accent)]/20 transition-colors">
+              <User size={14} className="text-[var(--color-fin-accent)]" />
+            </div>
+            View Profile
+          </button>
+
+          <button
+            type="button"
+            onClick={onPreferences}
+            className="profile-dropdown-item flex items-center gap-3 group"
+          >
+            <div className="p-1.5 rounded-lg bg-blue-400/10 group-hover:bg-blue-400/20 transition-colors">
+              <Settings size={14} className="text-blue-400" />
+            </div>
+            Preferences
+          </button>
+
+          <div className="profile-dropdown-divider" />
+
+          <button
+            type="button"
+            onClick={onSignOut}
+            className="profile-dropdown-item profile-dropdown-item--danger flex items-center gap-3 group"
+            id="signout-btn"
+          >
+            <div className="p-1.5 rounded-lg bg-red-400/10 group-hover:bg-red-400/20 transition-colors">
+              <LogOut size={14} className="text-red-400" />
+            </div>
+            Sign out
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
 export default function Header() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -23,9 +146,7 @@ export default function Header() {
 
   const handleSignOut = async () => {
     setProfileOpen(false);
-
     const signedOut = await signOut();
-
     if (signedOut) {
       navigate("/signin");
     }
@@ -50,8 +171,8 @@ export default function Header() {
     return "";
   };
 
-  // Extract display name and email from Supabase user
-  const displayName = user?.user_metadata?.full_name || user?.email?.split("@")[0] || "User";
+  const displayName =
+    user?.user_metadata?.full_name || user?.email?.split("@")[0] || "User";
   const displayEmail = user?.email || "";
   const initials = displayName
     .split(" ")
@@ -67,10 +188,21 @@ export default function Header() {
         backdropFilter: "blur(12px)",
       }}
     >
-      <label htmlFor="mobile-drawer"
+      <label
+        htmlFor="mobile-drawer"
         className="theme-icon-button p-2 cursor-pointer rounded-lg transition-colors lg:hidden"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
           <line x1="3" y1="12" x2="21" y2="12"></line>
           <line x1="3" y1="6" x2="21" y2="6"></line>
           <line x1="3" y1="18" x2="21" y2="18"></line>
@@ -81,109 +213,35 @@ export default function Header() {
         <h1 className="text-base font-bold text-[var(--color-fin-text)] tracking-wide leading-tight">
           {getPageTitle()}
         </h1>
-        <p className="text-xs text-[var(--color-fin-muted)] leading-tight">{getPageSubtitle()}</p>
+        <p className="text-xs text-[var(--color-fin-muted)] leading-tight">
+          {getPageSubtitle()}
+        </p>
       </div>
 
-      {/* ── Auth / Profile section ─────────────────────────────────── */}
+      {/* Mutually exclusive: guests see Sign in/up; signed-in users see one profile menu */}
       <div className="flex items-center gap-3 relative ml-auto" ref={dropdownRef}>
         {!user ? (
-          <>
-            <button
-              type="button"
-              onClick={() => navigate("/signin")}
-              className="text-sm font-semibold text-[var(--color-fin-muted)] hover:text-[var(--color-fin-text)] transition-colors px-2 py-1.5"
-              id="guest-signin-btn"
-            >
-              Sign in
-            </button>
-            <button
-              type="button"
-              onClick={() => navigate("/signup")}
-              className="text-sm font-bold px-3 py-1.5 rounded-lg text-[var(--color-fin-text)] transition-colors"
-              style={{
-                background: "var(--color-fin-accent-soft)",
-                border: "1px solid color-mix(in srgb, var(--color-fin-accent) 35%, transparent)",
-              }}
-              id="guest-signup-btn"
-            >
-              Sign up
-            </button>
-          </>
+          <GuestAuthButtons
+            onSignIn={() => navigate("/signin")}
+            onSignUp={() => navigate("/signup")}
+          />
         ) : (
-          <>
-            <button
-              onClick={() => setProfileOpen(!profileOpen)}
-              className="profile-trigger"
-              id="profile-menu-btn"
-            >
-              <div className="profile-avatar">
-                {initials}
-              </div>
-              <span className="profile-name hidden md:block">{displayName}</span>
-              <ChevronDown
-                size={14}
-                className="profile-chevron hidden md:block"
-                style={{
-                  transform: profileOpen ? "rotate(180deg)" : "rotate(0deg)",
-                  transition: "transform 0.2s ease",
-                  color: "var(--color-fin-muted)",
-                }}
-              />
-            </button>
-
-            {profileOpen && (
-              <div className="profile-dropdown animate-in">
-                <div className="h-1 w-full rounded-t-xl mb-3"
-                  style={{ background: "linear-gradient(90deg, var(--color-fin-accent), #f97316)" }} />
-
-                <div className="profile-dropdown-header">
-                  <div className="w-10 h-10 rounded-xl flex items-center justify-center text-sm font-bold text-white shrink-0"
-                    style={{ background: "linear-gradient(135deg, var(--color-fin-accent), #f97316)" }}>
-                    {initials}
-                  </div>
-                  <div className="profile-dropdown-info">
-                    <span className="profile-dropdown-name">{displayName}</span>
-                    <span className="profile-dropdown-email">{displayEmail}</span>
-                  </div>
-                </div>
-
-                <div className="profile-dropdown-divider" />
-
-                <button
-                  onClick={() => { setProfileOpen(false); navigate("/profile"); }}
-                  className="profile-dropdown-item flex items-center gap-3 group"
-                >
-                  <div className="p-1.5 rounded-lg bg-[var(--color-fin-accent)]/10 group-hover:bg-[var(--color-fin-accent)]/20 transition-colors">
-                    <User size={14} className="text-[var(--color-fin-accent)]" />
-                  </div>
-                  View Profile
-                </button>
-
-                <button
-                  onClick={() => { setProfileOpen(false); navigate("/preferences"); }}
-                  className="profile-dropdown-item flex items-center gap-3 group"
-                >
-                  <div className="p-1.5 rounded-lg bg-blue-400/10 group-hover:bg-blue-400/20 transition-colors">
-                    <Settings size={14} className="text-blue-400" />
-                  </div>
-                  Preferences
-                </button>
-
-                <div className="profile-dropdown-divider" />
-
-                <button
-                  onClick={handleSignOut}
-                  className="profile-dropdown-item profile-dropdown-item--danger flex items-center gap-3 group"
-                  id="signout-btn"
-                >
-                  <div className="p-1.5 rounded-lg bg-red-400/10 group-hover:bg-red-400/20 transition-colors">
-                    <LogOut size={14} className="text-red-400" />
-                  </div>
-                  Sign out
-                </button>
-              </div>
-            )}
-          </>
+          <AuthenticatedProfileMenu
+            displayName={displayName}
+            displayEmail={displayEmail}
+            initials={initials}
+            profileOpen={profileOpen}
+            setProfileOpen={setProfileOpen}
+            onViewProfile={() => {
+              setProfileOpen(false);
+              navigate("/profile");
+            }}
+            onPreferences={() => {
+              setProfileOpen(false);
+              navigate("/preferences");
+            }}
+            onSignOut={handleSignOut}
+          />
         )}
       </div>
     </header>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "react-router-dom";
 import finbGif from "../../assets/finboard.gif";
+import { useAuth } from "../../context/useAuth";
 
 import {
   LayoutDashboard,
@@ -9,18 +10,18 @@ import {
   Settings,
   Target,
   CircleHelp,
-  UserCircle,
-  SlidersHorizontal,
+  Lock,
 } from "lucide-react";
 
 export default function Sidebar() {
   const location = useLocation();
   const path = location.pathname;
+  const { user } = useAuth();
 
   const links = [
     { name: "Home", to: "/", icon: LayoutDashboard },
-    { name: "Budgets", to: "/budgets", icon: PiggyBank },
-    { name: "Goals", to: "/goals", icon: Target },
+    { name: "Budgets", to: "/budgets", icon: PiggyBank, requiresAuth: true },
+    { name: "Goals", to: "/goals", icon: Target, requiresAuth: true },
     { name: "Transactions", to: "/transaction", icon: ArrowLeftRight },
     { name: "Insights", to: "/insights", icon: BarChart2 },
     { name: "Settings", to: "/settings", icon: Settings },
@@ -67,11 +68,13 @@ export default function Sidebar() {
         {links.map((link) => {
           const isActive = path === link.to;
           const Icon = link.icon;
+          const isLocked = Boolean(link.requiresAuth && !user);
 
           return (
             <Link
               key={link.to}
               to={link.to}
+              title={isLocked ? "Create an account to use Budgets and Goals." : undefined}
               onClick={() => {
                 const drawer = document.getElementById("mobile-drawer");
                 if (drawer) drawer.checked = false;
@@ -105,7 +108,14 @@ export default function Sidebar() {
                 }
               />
               {link.name}
-              {isActive && (
+              {isLocked && (
+                <Lock
+                  size={14}
+                  className="ml-auto text-[var(--color-fin-muted)]"
+                  aria-label="Requires account"
+                />
+              )}
+              {!isLocked && isActive && (
                 <div className="ml-auto w-1.5 h-1.5 rounded-full bg-[var(--color-fin-accent)]" />
               )}
             </Link>

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -5,6 +5,54 @@ import { useAuth } from './useAuth';
 import { DataContext } from './DataContext';
 import { CURRENCIES } from '../lib/Currencies'
 
+const GUEST_TRANSACTIONS_KEY = 'transactions';
+const GUEST_CURRENCY_KEY = 'guest_currency';
+
+function readGuestTransactions() {
+  if (typeof window === 'undefined') return [];
+  try {
+    const stored = window.localStorage.getItem(GUEST_TRANSACTIONS_KEY);
+    if (stored === null) return [];
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeGuestTransactions(txs) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(GUEST_TRANSACTIONS_KEY, JSON.stringify(txs));
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.error('Failed to persist guest transactions:', err);
+    }
+  }
+}
+
+function readGuestCurrency() {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = window.localStorage.getItem(GUEST_CURRENCY_KEY);
+    if (!stored) return null;
+    return JSON.parse(stored);
+  } catch {
+    return null;
+  }
+}
+
+function writeGuestCurrency(selectedCurrency) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(GUEST_CURRENCY_KEY, JSON.stringify(selectedCurrency));
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.error('Failed to persist guest currency:', err);
+    }
+  }
+}
+
 export function AppContext({ children }) {
   const { user } = useAuth();
   const [transactions, setTransactions] = React.useState([]);
@@ -49,8 +97,14 @@ export function AppContext({ children }) {
   React.useEffect(() => {
     async function loadData() {
       if (!user) {
-        setTransactions([]);
-        setCurrency(CURRENCIES[0]);
+        const guestCurrency = readGuestCurrency() || CURRENCIES[0];
+        const guestTx = readGuestTransactions();
+        setCurrency(guestCurrency);
+        setTransactions(
+          guestTx.length
+            ? normalizeTransactions(guestTx, { currency: guestCurrency })
+            : []
+        );
         setLoadingData(false);
         return;
       }
@@ -120,6 +174,8 @@ export function AppContext({ children }) {
       await supabase
         .from('user_settings')
         .upsert({ user_id: user.id, currency: enrichedCurrency }, { onConflict: 'user_id' });
+    } else {
+      writeGuestCurrency(enrichedCurrency);
     }
   };
 
@@ -141,6 +197,9 @@ export function AppContext({ children }) {
       : transactions.filter((t) => t.id !== indexOrId);
 
     setTransactions(updated);
+    if (!user) {
+      writeGuestTransactions(updated);
+    }
   };
 
   const addTransaction = async (newTransaction) => {
@@ -169,9 +228,17 @@ export function AppContext({ children }) {
       if (data) {
         normalized.id = data.id;
       }
+    } else if (!normalized.id) {
+      normalized.id = `guest-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
     }
 
-    setTransactions((prev) => [...prev, normalized]);
+    setTransactions((prev) => {
+      const next = [...prev, normalized];
+      if (!user) {
+        writeGuestTransactions(next);
+      }
+      return next;
+    });
   };
 
   const updateTransaction = async (index, updatedTransaction) => {
@@ -202,9 +269,17 @@ export function AppContext({ children }) {
         }
         throw error;
       }
+    } else if (targetTx?.id) {
+      normalized.id = targetTx.id;
     }
 
-    setTransactions((prev) => prev.map((t, i) => i === index ? normalized : t));
+    setTransactions((prev) => {
+      const next = prev.map((t, i) => i === index ? normalized : t);
+      if (!user) {
+        writeGuestTransactions(next);
+      }
+      return next;
+    });
   };
 
   const displayTransactions = React.useMemo(() => {

--- a/src/pages/Budgets.jsx
+++ b/src/pages/Budgets.jsx
@@ -84,41 +84,39 @@ export default function Budgets() {
     .filter((item) => item.budget > 0);
 
   const handleBudgetChange = async (category, value) => {
+    if (!user) return;
+
     const numValue = Number(value);
     if (numValue >= 0) {
       setBudgets(prev => ({ ...prev, [category]: numValue }));
-      
-      if (user) {
-        await supabase
-          .from('budgets')
-          .upsert(
-            { user_id: user.id, category, amount: numValue },
-            { onConflict: 'user_id, category' }
-          );
-      }
+
+      await supabase
+        .from('budgets')
+        .upsert(
+          { user_id: user.id, category, amount: numValue },
+          { onConflict: 'user_id, category' }
+        );
     } else if (value === "") {
       const newBudgets = { ...budgets };
       delete newBudgets[category];
       setBudgets(newBudgets);
-      
-      if (user) {
-        await supabase
-          .from('budgets')
-          .delete()
-          .match({ user_id: user.id, category });
-      }
+
+      await supabase
+        .from('budgets')
+        .delete()
+        .match({ user_id: user.id, category });
     }
   };
 
   const resetBudgets = () => {
+    if (!user) return;
+
     showModal({
       type: "confirm",
       message: "Are you sure you want to reset all budgets?",
       onConfirm: async () => {
         setBudgets({});
-        if (user) {
-          await supabase.from('budgets').delete().eq('user_id', user.id);
-        }
+        await supabase.from('budgets').delete().eq('user_id', user.id);
       },
     });
   };

--- a/src/pages/Goals.jsx
+++ b/src/pages/Goals.jsx
@@ -60,7 +60,7 @@ export default function Goals() {
 
   const handleAddGoal = async (e) => {
     e.preventDefault();
-    if (!form.name || !form.target || !form.deadline || !user) return;
+    if (!user || !form.name || !form.target || !form.deadline) return;
 
     const newGoal = {
       name: form.name,
@@ -86,19 +86,21 @@ export default function Goals() {
   };
 
   const handleDelete = (id) => {
+    if (!user) return;
+
     showModal({
       type: "confirm",
       message: "Are you sure you want to delete this goal? Any allocated funds will be returned to your unallocated savings.",
       onConfirm: async () => {
         setGoals(goals.filter((g) => g.id !== id));
-        if (user) {
-          await supabase.from('goals').delete().eq('id', id);
-        }
+        await supabase.from('goals').delete().eq('id', id);
       },
     });
   };
 
   const handleAllocate = async (goalId, isWithdrawal = false) => {
+    if (!user) return;
+
     const amount = Number(allocationAmount);
     if (!amount || amount <= 0) return;
 
@@ -124,9 +126,7 @@ export default function Goals() {
     setAllocationGoalId(null);
     setAllocationAmount("");
 
-    if (user) {
-      await supabase.from('goals').update({ saved_amount: newSavedAmount }).eq('id', goalId);
-    }
+    await supabase.from('goals').update({ saved_amount: newSavedAmount }).eq('id', goalId);
   };
 
   const getProgress = (saved, target) => {

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -143,6 +143,12 @@ export default function Settings() {
                 if (data[idx]) t.id = data[idx].id;
               });
             }
+          } else {
+            normalizedData.forEach((t, idx) => {
+              if (!t.id) {
+                t.id = `guest-${Date.now()}-${idx}-${Math.random().toString(36).slice(2, 7)}`;
+              }
+            });
           }
 
           const updatedData =
@@ -219,6 +225,7 @@ export default function Settings() {
       onConfirm: () => {
         setTransactions([]);
         localStorage.removeItem("transactions");
+        localStorage.removeItem("guest_currency");
         setSuccessMessage("All Data Cleared!");
         setTimeout(() => setSuccessMessage(""), 3000);
       },
@@ -303,6 +310,12 @@ export default function Settings() {
                         if (data[idx]) t.id = data[idx].id;
                       });
                     }
+                  } else {
+                    normalized.forEach((t, idx) => {
+                      if (!t.id) {
+                        t.id = `guest-${Date.now()}-${idx}-${Math.random().toString(36).slice(2, 7)}`;
+                      }
+                    });
                   }
 
                   const updated = importMode === "append" ? [...(transactions || []), ...normalized] : normalized;

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -1,11 +1,23 @@
 import * as React from 'react';
-import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useNavigate, useLocation, Link as RouterLink } from 'react-router-dom';
 import { supabase } from '../lib/supabaseClient';
 import ForgotPassword from './ForgotPassword';
 import { Eye, EyeOff, Mail, Lock, LogIn, Loader2 } from 'lucide-react';
 
+function getPostAuthPath(location) {
+  const from = location.state?.from;
+  if (from && typeof from.pathname === 'string') {
+    return `${from.pathname}${from.search || ''}`;
+  }
+  return '/dashboard';
+}
+
 export default function SignIn() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const showPremiumUpsell = searchParams.get('reason') === 'budgets-goals';
+  const postAuthPath = getPostAuthPath(location);
 
   const [email, setEmail] = React.useState('');
   const [password, setPassword] = React.useState('');
@@ -88,7 +100,7 @@ export default function SignIn() {
       }
       if (data?.user) {
         setAuthSuccess('Signed in! Redirecting…');
-        setTimeout(() => navigate('/dashboard'), 600);
+        setTimeout(() => navigate(postAuthPath, { replace: true }), 600);
       }
     } catch {
       setAuthError('An unexpected error occurred. Please try again.');
@@ -132,6 +144,20 @@ export default function SignIn() {
           <h1 className="auth-title">Welcome back</h1>
           <p className="auth-subtitle">Sign in to your account to continue</p>
         </div>
+
+        {showPremiumUpsell && (
+          <div
+            className="auth-alert"
+            role="status"
+            style={{
+              background: 'rgba(249, 115, 22, 0.1)',
+              border: '1px solid rgba(249, 115, 22, 0.3)',
+              color: 'var(--color-fin-accent, #f97316)',
+            }}
+          >
+            <span>Create an account to use Budgets and Goals.</span>
+          </div>
+        )}
 
         {/* Alerts */}
         {authError && (
@@ -274,7 +300,13 @@ export default function SignIn() {
         {/* Footer */}
         <p className="auth-footer-text">
           Don't have an account?{' '}
-          <RouterLink to="/signup" className="auth-link">Sign up</RouterLink>
+          <RouterLink
+            to={showPremiumUpsell ? '/signup?reason=budgets-goals' : '/signup'}
+            state={location.state}
+            className="auth-link"
+          >
+            Sign up
+          </RouterLink>
         </p>
       </div>
     </div>

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,10 +1,22 @@
 import * as React from 'react';
-import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useNavigate, useLocation, Link as RouterLink } from 'react-router-dom';
 import { supabase } from '../lib/supabaseClient';
 import { Eye, EyeOff, Mail, Lock, User, UserPlus, Loader2 } from 'lucide-react';
 
+function getPostAuthPath(location) {
+  const from = location.state?.from;
+  if (from && typeof from.pathname === 'string') {
+    return `${from.pathname}${from.search || ''}`;
+  }
+  return '/dashboard';
+}
+
 export default function SignUp() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const showPremiumUpsell = searchParams.get('reason') === 'budgets-goals';
+  const postAuthPath = getPostAuthPath(location);
 
   const [name, setName] = React.useState('');
   const [email, setEmail] = React.useState('');
@@ -121,7 +133,7 @@ export default function SignUp() {
 
       if (data?.session) {
         setAuthSuccess('Account created! Redirecting…');
-        setTimeout(() => navigate('/dashboard'), 600);
+        setTimeout(() => navigate(postAuthPath, { replace: true }), 600);
       } else {
         setAuthSuccess('Account created! Check your email to verify before signing in.');
       }
@@ -166,6 +178,20 @@ export default function SignUp() {
           <h1 className="auth-title">Create your account</h1>
           <p className="auth-subtitle">Start managing your finances today</p>
         </div>
+
+        {showPremiumUpsell && (
+          <div
+            className="auth-alert"
+            role="status"
+            style={{
+              background: 'rgba(249, 115, 22, 0.1)',
+              border: '1px solid rgba(249, 115, 22, 0.3)',
+              color: 'var(--color-fin-accent, #f97316)',
+            }}
+          >
+            <span>Create an account to use Budgets and Goals.</span>
+          </div>
+        )}
 
         {/* Alerts */}
         {authError && (
@@ -338,7 +364,13 @@ export default function SignUp() {
         {/* Footer */}
         <p className="auth-footer-text">
           Already have an account?{' '}
-          <RouterLink to="/signin" className="auth-link">Sign in</RouterLink>
+          <RouterLink
+            to={showPremiumUpsell ? '/signin?reason=budgets-goals' : '/signin'}
+            state={location.state}
+            className="auth-link"
+          >
+            Sign in
+          </RouterLink>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Allow guests to use free FinBoard routes (dashboard, transactions, settings, insights, help, preferences) without signing in.
- Hard-gate Budgets, Goals, and Profile behind auth; redirect guests to `/signin` with return path + upsell: “Create an account to use Budgets and Goals.”
- Persist guest free-feature data in `localStorage` only; Supabase writes run only when authenticated.

Closes #238

## Test plan
- [x] As a guest, open Dashboard / Transactions / Settings / Insights / Help without being redirected to sign-in
- [x] As a guest, add or import transactions and confirm they persist after refresh (localStorage) with no Supabase writes
- [x] As a guest, open Budgets or Goals → land on `/signin?reason=budgets-goals` with the upsell message
- [x] Sign in from that flow → return to the intended Budgets/Goals route
- [x] As an authenticated user, Budgets/Goals add/edit/delete/allocate still sync to Supabase
- [x] As a guest, Profile is blocked; Header shows Sign in / Sign up (no profile dropdown crash)
- [x] Sidebar shows lock affordance on Budgets/Goals for guests