### PR TITLE
fix: add global error boundary to prevent full app crashes (#251)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import ErrorBoundary from "./components/ErrorBoundary";
 import Dashboard from "./pages/Dashboard";
 import Budgets from "./pages/Budgets";
 import Goals from "./pages/Goals";
@@ -64,71 +65,73 @@ export default function App() {
   }
 
   return (
-    <ThemeProvider>
-      <AuthProvider>
-        <AppContext>
-          <ModalProvider>
-            <BrowserRouter>
-              <Routes>
-                {/* Public auth routes */}
-                <Route
-                  path="/signin"
-                  element={
-                    <GuestRoute>
-                      <SignIn />
-                    </GuestRoute>
-                  }
-                />
-                <Route
-                  path="/signup"
-                  element={
-                    <GuestRoute>
-                      <SignUp />
-                    </GuestRoute>
-                  }
-                />
-                <Route path="/reset-password" element={<ResetPassword />} />
+    <ErrorBoundary>
+      <ThemeProvider>
+        <AuthProvider>
+          <AppContext>
+            <ModalProvider>
+              <BrowserRouter>
+                <Routes>
+                  {/* Public auth routes */}
+                  <Route
+                    path="/signin"
+                    element={
+                      <GuestRoute>
+                        <SignIn />
+                      </GuestRoute>
+                    }
+                  />
+                  <Route
+                    path="/signup"
+                    element={
+                      <GuestRoute>
+                        <SignUp />
+                      </GuestRoute>
+                    }
+                  />
+                  <Route path="/reset-password" element={<ResetPassword />} />
 
-                {/* App shell — free routes are guest-accessible; premium routes are gated */}
-                <Route path="/" element={<Layout />}>
-                  <Route index element={<Dashboard />} />
-                  <Route path="dashboard" element={<Dashboard />} />
-                  <Route path="settings" element={<Settings />} />
-                  <Route path="transaction" element={<Transaction />} />
-                  <Route path="insights" element={<InsightsDashboard />} />
-                  <Route path="preferences" element={<Preferences />} />
-                  <Route path="help" element={<HelpCenter />} />
-                  <Route
-                    path="budgets"
-                    element={
-                      <ProtectedRoute>
-                        <Budgets />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="goals"
-                    element={
-                      <ProtectedRoute>
-                        <Goals />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="profile"
-                    element={
-                      <ProtectedRoute>
-                        <Profile />
-                      </ProtectedRoute>
-                    }
-                  />
-                </Route>
-              </Routes>
-            </BrowserRouter>
-            <Modal />
-          </ModalProvider>
-        </AppContext>
-      </AuthProvider>
-    </ThemeProvider>
+                  {/* App shell — free routes are guest-accessible; premium routes are gated */}
+                  <Route path="/" element={<Layout />}>
+                    <Route index element={<Dashboard />} />
+                    <Route path="dashboard" element={<Dashboard />} />
+                    <Route path="settings" element={<Settings />} />
+                    <Route path="transaction" element={<Transaction />} />
+                    <Route path="insights" element={<InsightsDashboard />} />
+                    <Route path="preferences" element={<Preferences />} />
+                    <Route path="help" element={<HelpCenter />} />
+                    <Route
+                      path="budgets"
+                      element={
+                        <ProtectedRoute>
+                          <Budgets />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="goals"
+                      element={
+                        <ProtectedRoute>
+                          <Goals />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="profile"
+                      element={
+                        <ProtectedRoute>
+                          <Profile />
+                        </ProtectedRoute>
+                      }
+                    />
+                  </Route>
+                </Routes>
+              </BrowserRouter>
+              <Modal />
+            </ModalProvider>
+          </AppContext>
+        </AuthProvider>
+      </ThemeProvider>
+    </ErrorBoundary>
   );
 }

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,166 @@
+import { Component } from "react";
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+    this.handleReset = this.handleReset.bind(this);
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("[ErrorBoundary]", error, info.componentStack);
+  }
+
+  handleReset() {
+    this.setState({ hasError: false, error: null });
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    const { error } = this.state;
+
+    return (
+      <div style={styles.root}>
+        <div style={styles.card}>
+          <div style={styles.iconWrap}>
+            <svg
+              width="40"
+              height="40"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="var(--color-fin-accent)"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+          </div>
+
+          <h1 style={styles.heading}>Something went wrong</h1>
+          <p style={styles.body}>
+            An unexpected error occurred. You can try to recover below, or
+            reload the page if the problem persists.
+          </p>
+
+          {error?.message && (
+            <pre style={styles.errorBlock}>
+              <span style={styles.errorLabel}>Error</span>
+              {error.message}
+            </pre>
+          )}
+
+          <div style={styles.actions}>
+            <button style={styles.btnPrimary} onClick={this.handleReset}>
+              Try again
+            </button>
+            <button
+              style={styles.btnOutline}
+              onClick={() => window.location.reload()}
+            >
+              Reload page
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+const styles = {
+  root: {
+    minHeight: "100vh",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "var(--color-fin-bg)",
+    padding: "2rem",
+    fontFamily: "Inter, system-ui, sans-serif",
+  },
+  card: {
+    backgroundColor: "var(--color-fin-surface)",
+    border: "1px solid var(--color-fin-border)",
+    borderRadius: "16px",
+    padding: "2.5rem",
+    maxWidth: "480px",
+    width: "100%",
+    boxShadow: "0 8px 32px var(--color-fin-shadow)",
+  },
+  iconWrap: {
+    marginBottom: "1.25rem",
+  },
+  heading: {
+    color: "var(--color-fin-text)",
+    fontSize: "1.375rem",
+    fontWeight: 600,
+    margin: "0 0 0.625rem 0",
+    letterSpacing: "-0.01em",
+  },
+  body: {
+    color: "var(--color-fin-muted)",
+    fontSize: "0.9rem",
+    lineHeight: 1.6,
+    margin: "0 0 1.25rem 0",
+  },
+  errorBlock: {
+    backgroundColor: "var(--color-fin-bg)",
+    border: "1px solid var(--color-fin-border)",
+    borderRadius: "8px",
+    padding: "1rem",
+    fontSize: "0.8rem",
+    color: "var(--color-fin-text)",
+    overflowX: "auto",
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+    margin: "0 0 1.5rem 0",
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.4rem",
+  },
+  errorLabel: {
+    color: "var(--color-fin-accent)",
+    fontWeight: 600,
+    fontSize: "0.75rem",
+    textTransform: "uppercase",
+    letterSpacing: "0.06em",
+  },
+  actions: {
+    display: "flex",
+    gap: "0.75rem",
+    flexWrap: "wrap",
+  },
+  btnPrimary: {
+    backgroundColor: "var(--color-fin-accent)",
+    color: "#fff",
+    border: "none",
+    borderRadius: "8px",
+    padding: "0.6rem 1.25rem",
+    fontSize: "0.9rem",
+    fontWeight: 500,
+    cursor: "pointer",
+    fontFamily: "inherit",
+    transition: "opacity 0.15s",
+  },
+  btnOutline: {
+    backgroundColor: "transparent",
+    color: "var(--color-fin-accent)",
+    border: "1px solid var(--color-fin-accent)",
+    borderRadius: "8px",
+    padding: "0.6rem 1.25rem",
+    fontSize: "0.9rem",
+    fontWeight: 500,
+    cursor: "pointer",
+    fontFamily: "inherit",
+    transition: "background-color 0.15s",
+  },
+};


### PR DESCRIPTION
## Description
This PR addresses Issue #251 by introducing a global React `ErrorBoundary` at the top of the component tree in `App.jsx`. 

Previously, any unhandled render exception within the context providers or routing layer would crash the entire application, leaving the user stuck on a blank white screen. With this change, exceptions are caught gracefully and the user is presented with a themed, friendly fallback UI that allows them to attempt recovery.

## What changed
* **Created `ErrorBoundary.jsx`**: A new class component implementing `getDerivedStateFromError` and `componentDidCatch`.
* **Wrapped `App.jsx`**: The `ErrorBoundary` now wraps the entire provider and router tree. Note: The large diff in `App.jsx` is primarily due to the 2-space indentation shift required to wrap the existing `<ThemeProvider>` block.
* **Themed Fallback UI**: The error screen uses our existing CSS custom properties (e.g., `var(--color-fin-bg)`, `var(--color-fin-accent)`) so it adapts to both dark and light modes automatically, without any hardcoded colors.
* **Recovery Actions**: Added "Try again" (clears error state for a soft reset) and "Reload page" (hard refresh) buttons.

## Why a class component?
I opted for a standard class component rather than bringing in the `react-error-boundary` package. This keeps our dependencies light and avoids adding unnecessary bundle weight for functionality that React supports natively out of the box.

## Visual Proof

**Dark Mode**

<img width="1920" height="912" alt="error-boundary-dark" src="https://github.com/user-attachments/assets/ceac005a-f2aa-48cc-906e-2248413c14c4" />

**Light Mode**

<img width="1920" height="912" alt="error-boundary-light" src="https://github.com/user-attachments/assets/e366bb98-7409-454e-87ab-d683ae60725e" />


> The fallback UI was verified to be visually consistent with the overall website in both themes. All colors are resolved from the existing CSS custom properties defined in `index.css`.

## How to test
1. Pull this branch and start the dev server.
2. Open `App.jsx` and temporarily add a component that throws inside the `<ErrorBoundary>`.
3. Verify the fallback UI renders instead of a blank screen.
4. Click "Try again" and "Reload page" to confirm both recovery paths work.
5. Check the browser console for the `[ErrorBoundary]` log from `componentDidCatch`.

Closes #251
