### PR TITLE
feat: add Finny visibility and access gating (closes #239)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "node test/normalize.test.js"
+    "test": "node test/normalize.test.js && node test/finny.test.js"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/src/components/Finny/Finny.jsx
+++ b/src/components/Finny/Finny.jsx
@@ -2,17 +2,14 @@ import { useContext, useState } from "react";
 import { DataContext } from "../../context/DataContext";
 import { useAuth } from "../../context/useAuth";
 import FinnyPanel from "./FinnyPanel";
-
-const MIN_TRANSACTIONS_TO_SHOW = 5;
+import { shouldShowFinny } from "../../lib/finnyGating";
 
 export default function Finny() {
   const { transactions } = useContext(DataContext);
   const { user } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
 
-  const hasMinTransactions = (transactions?.length || 0) > MIN_TRANSACTIONS_TO_SHOW;
-
-  if (!hasMinTransactions) {
+  if (!shouldShowFinny(transactions?.length)) {
     return null;
   }
 

--- a/src/components/Finny/Finny.jsx
+++ b/src/components/Finny/Finny.jsx
@@ -1,0 +1,32 @@
+import { useContext, useState } from "react";
+import { DataContext } from "../../context/DataContext";
+import { useAuth } from "../../context/useAuth";
+import FinnyPanel from "./FinnyPanel";
+
+const MIN_TRANSACTIONS_TO_SHOW = 5;
+
+export default function Finny() {
+  const { transactions } = useContext(DataContext);
+  const { user } = useAuth();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const hasMinTransactions = (transactions?.length || 0) > MIN_TRANSACTIONS_TO_SHOW;
+
+  if (!hasMinTransactions) {
+    return null;
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        aria-label="Open Finny"
+        className="fixed bottom-6 right-6 z-50 btn btn-primary rounded-full shadow-lg px-5 py-3"
+      >
+        Finny
+      </button>
+      <FinnyPanel isOpen={isOpen} onClose={() => setIsOpen(false)} user={user} />
+    </>
+  );
+}

--- a/src/components/Finny/FinnyPanel.jsx
+++ b/src/components/Finny/FinnyPanel.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { useEffect, useRef } from "react";
 import { isFinnyAuthorized } from "../../lib/finnyGating";
 
@@ -43,8 +44,20 @@ export default function FinnyPanel({ isOpen, onClose, user }) {
         </div>
 
         {!isFinnyAuthorized(user) ? (
-          <p>Please sign in first to use Finny.</p>
-        ) : (
+  <div className="space-y-3">
+    <p>Please sign in first to use Finny.</p>
+
+    <div className="flex gap-2">
+      <Link to="/signin" className="btn btn-primary">
+        Sign in
+      </Link>
+
+      <Link to="/signup" className="btn btn-outline">
+        Sign up
+      </Link>
+    </div>
+  </div>
+) : (
           <p>Finny is ready. (Chatbot experience coming soon.)</p>
         )}
       </div>

--- a/src/components/Finny/FinnyPanel.jsx
+++ b/src/components/Finny/FinnyPanel.jsx
@@ -1,4 +1,24 @@
+import { useEffect, useRef } from "react";
+import { isFinnyAuthorized } from "../../lib/finnyGating";
+
 export default function FinnyPanel({ isOpen, onClose, user }) {
+  const panelRef = useRef(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    panelRef.current?.focus();
+
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
   if (!isOpen) {
     return null;
   }
@@ -10,7 +30,11 @@ export default function FinnyPanel({ isOpen, onClose, user }) {
       aria-modal="true"
       aria-label="Finny"
     >
-      <div className="bg-base-100 rounded-lg shadow-xl p-6 w-full max-w-sm mx-4">
+      <div
+        ref={panelRef}
+        tabIndex={-1}
+        className="bg-base-100 rounded-lg shadow-xl p-6 w-full max-w-sm mx-4 outline-none"
+      >
         <div className="flex justify-between items-center mb-4">
           <h2 className="font-semibold text-lg">Finny</h2>
           <button onClick={onClose} aria-label="Close Finny" className="btn btn-sm btn-ghost">
@@ -18,10 +42,9 @@ export default function FinnyPanel({ isOpen, onClose, user }) {
           </button>
         </div>
 
-        {!user ? (
+        {!isFinnyAuthorized(user) ? (
           <p>Please sign in first to use Finny.</p>
         ) : (
-          // Out of scope for this issue: chatbot Q&A flow / AI integration.
           <p>Finny is ready. (Chatbot experience coming soon.)</p>
         )}
       </div>

--- a/src/components/Finny/FinnyPanel.jsx
+++ b/src/components/Finny/FinnyPanel.jsx
@@ -1,0 +1,30 @@
+export default function FinnyPanel({ isOpen, onClose, user }) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Finny"
+    >
+      <div className="bg-base-100 rounded-lg shadow-xl p-6 w-full max-w-sm mx-4">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="font-semibold text-lg">Finny</h2>
+          <button onClick={onClose} aria-label="Close Finny" className="btn btn-sm btn-ghost">
+            ✕
+          </button>
+        </div>
+
+        {!user ? (
+          <p>Please sign in first to use Finny.</p>
+        ) : (
+          // Out of scope for this issue: chatbot Q&A flow / AI integration.
+          <p>Finny is ready. (Chatbot experience coming soon.)</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -2,6 +2,7 @@ import Header from "./Header";
 import Sidebar from "./Sidebar";
 import { Outlet } from "react-router-dom";
 import { useAuth } from "../../context/useAuth";
+import Finny from "../Finny/Finny";
 
 export default function Layout() {
   const { authError, clearAuthError } = useAuth();
@@ -29,7 +30,9 @@ export default function Layout() {
       <div className="drawer-side z-50">
         <label htmlFor="mobile-drawer" aria-label="close sidebar" className="drawer-overlay"></label> 
         <Sidebar />
-      </div>
+        </div>
+      <Finny />
     </div>
   );
 }
+

--- a/src/lib/finnyConstants.js
+++ b/src/lib/finnyConstants.js
@@ -1,0 +1,1 @@
+export const MIN_TRANSACTIONS_TO_SHOW = 5;

--- a/src/lib/finnyGating.js
+++ b/src/lib/finnyGating.js
@@ -1,0 +1,9 @@
+import { MIN_TRANSACTIONS_TO_SHOW } from './finnyConstants.js';
+
+export function shouldShowFinny(transactionCount) {
+  return (transactionCount || 0) > MIN_TRANSACTIONS_TO_SHOW;
+}
+
+export function isFinnyAuthorized(user) {
+  return Boolean(user);
+}

--- a/test/finny.test.js
+++ b/test/finny.test.js
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import { shouldShowFinny, isFinnyAuthorized } from '../src/lib/finnyGating.js';
+
+// visibility boundary
+assert.strictEqual(shouldShowFinny(5), false, 'hidden at exactly 5 transactions');
+assert.strictEqual(shouldShowFinny(6), true, 'visible at 6 transactions');
+assert.strictEqual(shouldShowFinny(0), false, 'hidden at 0 transactions');
+assert.strictEqual(shouldShowFinny(undefined), false, 'hidden when transactions is undefined');
+
+// auth gating
+assert.strictEqual(isFinnyAuthorized(null), false, 'unauthenticated when user is null');
+assert.strictEqual(isFinnyAuthorized({ id: 'abc' }), true, 'authenticated when user object present');
+
+console.log('All Finny gating tests passed');


### PR DESCRIPTION
Closes #239

## Changes
- Finny launcher renders only when `transactions.length > 5` (read from `DataContext`)
- Unauthenticated users see only "Please sign in first to use Finny." — no chatbot mount, no Q&A flow, no AI requests
- Mounted globally in `Layout.jsx`

## Scope
Visibility + access control only, per issue — chatbot Q&A/AI integration left as placeholder for a future issue.

## Testing
`npm run lint` and `npm run build` pass. Manually verified: hidden with ≤5 transactions, visible with >5, sign-in message shown when logged out, placeholder shown when logged in.