### PR TITLE
docs: fix unclosed code fences breaking Node.js setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,21 +96,24 @@ Choose your preferred setup:
 
 ### Option 1 — Node.js (Classic)
 
-```bash
-# Clone the repository
+1. Clone the repository
+
+`````bash
 git clone https://github.com/khanirfan18/finBoard.git
 cd finBoard
+`````
 
 2. Install packages
 
-```bash
+`````bash
 npm install
+`````
 
 3. Start development server
 
-```bash
+`````bash
 npm run dev
-```
+`````
 
 Open http://localhost:5173
 


### PR DESCRIPTION
PR Description: Fixed broken/unclosed code fences in README.md's "Option 1 — Node.js (Classic)" setup instructions — the numbered steps and commands were being swallowed into a single unclosed code block instead of rendering correctly. Also added the missing step 1 label.

Issue: closes #None (just a documentation quick fix )